### PR TITLE
Documentation improvements, code cleaned up

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -59,7 +59,7 @@ type dbThresholdKey struct {
 	N                              string
 }
 
-func (this *dbThresholdKey) FromThresholdKey(key *ThresholdKey) {
+func (this *dbThresholdKey) FromThresholdPublicKey(key *ThresholdPublicKey) {
 	this.TotalNumberOfDecryptionServers = key.TotalNumberOfDecryptionServers
 	this.Threshold = key.Threshold
 	this.V = fmt.Sprintf("%x", key.V)
@@ -70,7 +70,7 @@ func (this *dbThresholdKey) FromThresholdKey(key *ThresholdKey) {
 	}
 }
 
-func (this *dbThresholdKey) ToThresholdKey(key *ThresholdKey) error {
+func (this *dbThresholdKey) ToThresholdPublicKey(key *ThresholdPublicKey) error {
 	key.TotalNumberOfDecryptionServers = this.TotalNumberOfDecryptionServers
 	key.Threshold = this.Threshold
 	oks := make([]bool, 2)
@@ -91,18 +91,18 @@ func (this *dbThresholdKey) ToThresholdKey(key *ThresholdKey) error {
 	return nil
 }
 
-func (this *ThresholdKey) GetBSON() (interface{}, error) {
+func (this *ThresholdPublicKey) GetBSON() (interface{}, error) {
 	r := new(dbThresholdKey)
-	r.FromThresholdKey(this)
+	r.FromThresholdPublicKey(this)
 	return r, nil
 }
 
-func (this *ThresholdKey) SetBSON(raw bson.Raw) error {
+func (this *ThresholdPublicKey) SetBSON(raw bson.Raw) error {
 	r := new(dbThresholdKey)
 	if err := raw.Unmarshal(r); err != nil {
 		return err
 	}
-	return r.ToThresholdKey(this)
+	return r.ToThresholdPublicKey(this)
 }
 
 type dbPrivateKey struct {
@@ -175,7 +175,7 @@ func (this *dbPartialDecryptionZKP) FromPartialDecryptionZKP(pd *PartialDecrypti
 }
 
 func (this *dbPartialDecryptionZKP) ToPartialDecryptionZKP(pd *PartialDecryptionZKP) error {
-	pd.Key = new(ThresholdKey)
+	pd.Key = new(ThresholdPublicKey)
 
 	var oks = make([]bool, 6)
 

--- a/encoding.go
+++ b/encoding.go
@@ -57,7 +57,6 @@ type dbThresholdKey struct {
 	V                              string
 	Vi                             []string
 	N                              string
-	G                              string
 }
 
 func (this *dbThresholdKey) FromThresholdKey(key *ThresholdKey) {
@@ -65,7 +64,6 @@ func (this *dbThresholdKey) FromThresholdKey(key *ThresholdKey) {
 	this.Threshold = key.Threshold
 	this.V = fmt.Sprintf("%x", key.V)
 	this.N = fmt.Sprintf("%x", key.N)
-	this.G = fmt.Sprintf("%x", key.G)
 	this.Vi = make([]string, len(key.Vi))
 	for i, vi := range key.Vi {
 		this.Vi[i] = fmt.Sprintf("%x", vi)
@@ -75,10 +73,9 @@ func (this *dbThresholdKey) FromThresholdKey(key *ThresholdKey) {
 func (this *dbThresholdKey) ToThresholdKey(key *ThresholdKey) error {
 	key.TotalNumberOfDecryptionServers = this.TotalNumberOfDecryptionServers
 	key.Threshold = this.Threshold
-	oks := make([]bool, 3)
+	oks := make([]bool, 2)
 	key.V, oks[0] = new(big.Int).SetString(this.V, 16)
 	key.N, oks[1] = new(big.Int).SetString(this.N, 16)
-	key.G, oks[2] = new(big.Int).SetString(this.G, 16)
 	if !all(oks) {
 		return errors.New("not hexadecimal")
 	}
@@ -110,7 +107,6 @@ func (this *ThresholdKey) SetBSON(raw bson.Raw) error {
 
 type dbPrivateKey struct {
 	N      string `bson:",omitempty"`
-	G      string `bson:",omitempty"`
 	Lambda string `bson:",omitempty"`
 	Mu     string `bson:",omitempty"`
 }
@@ -154,7 +150,6 @@ type dbPartialDecryptionZKP struct {
 	E                              string   `json:"e"`
 	C                              string   `json:"c"`
 	V                              string   `json:"v"`
-	G                              string   `json:"g"`
 	N                              string   `json:"n"`
 	Vi                             []string `json:"vi"`
 	Decryption                     string   `json:"decryption"`
@@ -169,7 +164,6 @@ func (this *dbPartialDecryptionZKP) FromPartialDecryptionZKP(pd *PartialDecrypti
 	this.Threshold = pd.Key.Threshold
 	this.Z = fmt.Sprintf("%x", pd.Z)
 	this.E = fmt.Sprintf("%x", pd.E)
-	this.G = fmt.Sprintf("%x", pd.Key.G)
 	this.N = fmt.Sprintf("%x", pd.Key.N)
 	this.C = fmt.Sprintf("%x", pd.C)
 	this.V = fmt.Sprintf("%x", pd.Key.V)
@@ -183,7 +177,7 @@ func (this *dbPartialDecryptionZKP) FromPartialDecryptionZKP(pd *PartialDecrypti
 func (this *dbPartialDecryptionZKP) ToPartialDecryptionZKP(pd *PartialDecryptionZKP) error {
 	pd.Key = new(ThresholdKey)
 
-	var oks = make([]bool, 7)
+	var oks = make([]bool, 6)
 
 	pd.Id = this.Id
 	pd.Key.TotalNumberOfDecryptionServers = this.TotalNumberOfDecryptionServers
@@ -192,9 +186,8 @@ func (this *dbPartialDecryptionZKP) ToPartialDecryptionZKP(pd *PartialDecryption
 	pd.E, oks[1] = new(big.Int).SetString(this.E, 16)
 	pd.C, oks[2] = new(big.Int).SetString(this.C, 16)
 	pd.Key.V, oks[3] = new(big.Int).SetString(this.V, 16)
-	pd.Key.G, oks[4] = new(big.Int).SetString(this.G, 16)
-	pd.Key.N, oks[5] = new(big.Int).SetString(this.N, 16)
-	pd.Decryption, oks[6] = new(big.Int).SetString(this.Decryption, 16)
+	pd.Key.N, oks[4] = new(big.Int).SetString(this.N, 16)
+	pd.Decryption, oks[5] = new(big.Int).SetString(this.Decryption, 16)
 
 	if !all(oks) {
 		fmt.Println(oks)

--- a/encoding.go
+++ b/encoding.go
@@ -117,17 +117,12 @@ type dbPrivateKey struct {
 
 func (this *PrivateKey) GetBSON() (interface{}, error) {
 	m := make(map[string]string)
-	if this.G != nil {
-		m["g"] = fmt.Sprintf("%x", this.G)
-	}
+
 	if this.N != nil {
 		m["n"] = fmt.Sprintf("%x", this.N)
 	}
 	if this.Lambda != nil {
 		m["lambda"] = fmt.Sprintf("%x", this.Lambda)
-	}
-	if this.Mu != nil {
-		m["mu"] = fmt.Sprintf("%x", this.Mu)
 	}
 	return m, nil
 }
@@ -143,20 +138,12 @@ func (this *PrivateKey) SetBSON(raw bson.Raw) error {
 			return err
 		}
 	}
-	if c.G != "" {
-		this.G, err = fromHex(c.G)
-		if err != nil {
-			return err
-		}
-	}
+
 	if c.Lambda != "" {
 		this.Lambda, err = fromHex(c.Lambda)
 		if err != nil {
 			return err
 		}
-	}
-	if c.Mu != "" {
-		this.Mu, err = fromHex(c.Mu)
 	}
 
 	return err

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -118,6 +118,6 @@ func TestPartialDecryptionZKPBSONification(t *testing.T) {
 }
 
 func TestThresholdKeyBSON(t *testing.T) {
-	key := &ThresholdKey{PublicKey{b(9), b(8)}, 7, 6, b(3), []*big.Int{b(2), b(34)}}
+	key := &ThresholdKey{PublicKey{b(9)}, 7, 6, b(3), []*big.Int{b(2), b(34)}, b(8)}
 	AssertBSONIsGood(key, new(ThresholdKey), t)
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -85,14 +85,13 @@ func TestPartialDecryptionZKPJsonification(t *testing.T) {
 	pd.Key.Threshold = 98
 	pd.Key.TotalNumberOfDecryptionServers = 230
 	pd.Id = 1
-	pd.Key.Vi = []*big.Int{b(77), b(67)} // vi is 67
+	pd.Key.Vi = []*big.Int{b(77), b(67)}
 	pd.Key.N = b(131)
 	pd.Key.V = b(101)
 	pd.Decryption = b(171)
 	pd.E = b(112)
 	pd.C = b(99)
 	pd.Key.N = b(345)
-	pd.Key.G = b(99)
 	pd.Z = b(88)
 
 	AssertJSONIsGood(pd, new(PartialDecryptionZKP), t)
@@ -111,13 +110,18 @@ func TestPartialDecryptionZKPBSONification(t *testing.T) {
 	pd.E = b(112)
 	pd.C = b(99)
 	pd.Key.N = b(345)
-	pd.Key.G = b(99)
 	pd.Z = b(88)
 
 	AssertBSONIsGood(pd, new(PartialDecryptionZKP), t)
 }
 
 func TestThresholdKeyBSON(t *testing.T) {
-	key := &ThresholdKey{PublicKey{b(9)}, 7, 6, b(3), []*big.Int{b(2), b(34)}, b(8)}
+	key := &ThresholdKey{
+		PublicKey:                      PublicKey{b(9)},
+		TotalNumberOfDecryptionServers: 7,
+		Threshold:                      6,
+		V:                              b(3),
+		Vi:                             []*big.Int{b(2), b(34)},
+	}
 	AssertBSONIsGood(key, new(ThresholdKey), t)
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -118,6 +118,6 @@ func TestPartialDecryptionZKPBSONification(t *testing.T) {
 }
 
 func TestThresholdKeyBSON(t *testing.T) {
-	key := &ThresholdKey{PublicKey{b(9), b(8), nil}, 7, 6, b(3), []*big.Int{b(2), b(34)}}
+	key := &ThresholdKey{PublicKey{b(9), b(8)}, 7, 6, b(3), []*big.Int{b(2), b(34)}}
 	AssertBSONIsGood(key, new(ThresholdKey), t)
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -81,7 +81,7 @@ func TestGetBSONEmptyKey(t *testing.T) {
 
 func TestPartialDecryptionZKPJsonification(t *testing.T) {
 	pd := new(PartialDecryptionZKP)
-	pd.Key = new(ThresholdKey)
+	pd.Key = new(ThresholdPublicKey)
 	pd.Key.Threshold = 98
 	pd.Key.TotalNumberOfDecryptionServers = 230
 	pd.Id = 1
@@ -99,7 +99,7 @@ func TestPartialDecryptionZKPJsonification(t *testing.T) {
 
 func TestPartialDecryptionZKPBSONification(t *testing.T) {
 	pd := new(PartialDecryptionZKP)
-	pd.Key = new(ThresholdKey)
+	pd.Key = new(ThresholdPublicKey)
 	pd.Key.Threshold = 98
 	pd.Key.TotalNumberOfDecryptionServers = 230
 	pd.Id = 1
@@ -116,12 +116,12 @@ func TestPartialDecryptionZKPBSONification(t *testing.T) {
 }
 
 func TestThresholdKeyBSON(t *testing.T) {
-	key := &ThresholdKey{
+	key := &ThresholdPublicKey{
 		PublicKey:                      PublicKey{b(9)},
 		TotalNumberOfDecryptionServers: 7,
 		Threshold:                      6,
 		V:                              b(3),
 		Vi:                             []*big.Int{b(2), b(34)},
 	}
-	AssertBSONIsGood(key, new(ThresholdKey), t)
+	AssertBSONIsGood(key, new(ThresholdPublicKey), t)
 }

--- a/paillier.go
+++ b/paillier.go
@@ -7,12 +7,11 @@ import (
 )
 
 type PublicKey struct {
-	N, G *big.Int // usually G is set to N+1
+	N *big.Int // usually G is set to N+1
 }
 
 func (this *PublicKey) GetBSON() (interface{}, error) {
 	m := make(map[string]string)
-	m["g"] = fmt.Sprintf("%x", this.G)
 	m["n"] = fmt.Sprintf("%x", this.N)
 	return m, nil
 }
@@ -57,8 +56,7 @@ type PrivateKey struct {
 }
 
 func (this *PrivateKey) String() string {
-	ret := fmt.Sprintf("g     :  %x", this.G)
-	ret += fmt.Sprintf("n     :  %x", this.N)
+	ret := fmt.Sprintf("n     :  %x", this.N)
 	ret += fmt.Sprintf("lambda:  %x", this.Lambda)
 	return ret
 }

--- a/paillier.go
+++ b/paillier.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PublicKey struct {
-	N *big.Int // usually G is set to N+1
+	N *big.Int
 }
 
 func (this *PublicKey) GetBSON() (interface{}, error) {

--- a/paillier.go
+++ b/paillier.go
@@ -8,7 +8,6 @@ import (
 
 type PublicKey struct {
 	N, G *big.Int // usually G is set to N+1
-	n2   *big.Int // the cache value of N^2
 }
 
 func (this *PublicKey) GetBSON() (interface{}, error) {
@@ -19,11 +18,7 @@ func (this *PublicKey) GetBSON() (interface{}, error) {
 }
 
 func (this *PublicKey) GetNSquare() *big.Int {
-	if this.n2 != nil {
-		return this.n2
-	}
-	this.n2 = new(big.Int).Mul(this.N, this.N)
-	return this.n2
+	return new(big.Int).Mul(this.N, this.N)
 }
 
 // Encode a plaintext in a cypher one. The plain text must be smaller that

--- a/paillier.go
+++ b/paillier.go
@@ -37,6 +37,9 @@ func (pub *PublicKey) Encrypt(m *big.Int, random io.Reader) (*Cypher, error) {
 	}
 	nSquare := pub.GetNSquare()
 
+	// g is _always_ equal n+1
+	// Threshold encryption is safe only for g=n+1 choice.
+	// See [DJN 10], section 5.1
 	g := new(big.Int).Add(pub.N, big.NewInt(1))
 	gm := new(big.Int).Exp(g, m, nSquare)
 	rn := new(big.Int).Exp(r, pub.N, nSquare)

--- a/paillier.go
+++ b/paillier.go
@@ -55,12 +55,6 @@ type PrivateKey struct {
 	Lambda *big.Int
 }
 
-func (this *PrivateKey) String() string {
-	ret := fmt.Sprintf("n     :  %x", this.N)
-	ret += fmt.Sprintf("lambda:  %x", this.Lambda)
-	return ret
-}
-
 // Decodes ciphertext into a plaintext message.
 //
 // c - cyphertext to decrypt

--- a/paillier.go
+++ b/paillier.go
@@ -48,6 +48,9 @@ func (pub *PublicKey) Encrypt(m *big.Int, random io.Reader) (*Cypher, error) {
 
 // Takes two cypher texts and returns a 3rd one that encode
 // the sum of the two plain texts.
+//
+// It's possible because Paillier is a homomorphic encryption scheme, where
+// E(m1) * E(m2) = E(m1 + m2)
 func (this *PublicKey) Add(cypher1, cypher2 *Cypher) *Cypher {
 	m := new(big.Int).Mul(cypher1.C, cypher2.C)
 	return &Cypher{new(big.Int).Mod(m, this.GetNSquare())}

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func TestLCM(t *testing.T) {
-	a := big.NewInt(2 * 3 * 3 * 3 * 5 * 5)
-	b := big.NewInt(3 * 3 * 5 * 5 * 57 * 11)
-	exp := big.NewInt(3 * 3 * 5 * 5)
-	if reflect.DeepEqual(exp, LCM(a, b)) {
+	a := big.NewInt(1350)
+	b := big.NewInt(141075)
+	expected := big.NewInt(282150)
+
+	if !reflect.DeepEqual(expected, LCM(a, b)) {
 		t.Fail()
 	}
 }
@@ -35,7 +36,7 @@ func TestComputeMu(t *testing.T) {
 
 	exp := big.NewInt(3)
 	if !reflect.DeepEqual(computeMu(g, lambda, n), exp) {
-		t.Error("lambda is not well computed")
+		t.Error("mu is not well computed")
 	}
 }
 

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -40,6 +40,16 @@ func TestComputeMu(t *testing.T) {
 	}
 }
 
+func TestComputeLambda(t *testing.T) {
+	a := big.NewInt(5)
+	b := big.NewInt(7)
+	expected := big.NewInt(12)
+
+	if !reflect.DeepEqual(expected, computeLamda(a, b)) {
+		t.Error("lambda is not correctly computed")
+	}
+}
+
 func TestEncryptDecryptSmall(t *testing.T) {
 	p := big.NewInt(13)
 	q := big.NewInt(11)

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -7,46 +7,42 @@ import (
 	"testing"
 )
 
-func TestLCM(t *testing.T) {
-	a := big.NewInt(1350)
-	b := big.NewInt(141075)
-	expected := big.NewInt(282150)
-
-	if !reflect.DeepEqual(expected, LCM(a, b)) {
-		t.Fail()
-	}
-}
-
-func TestL(t *testing.T) {
+func TestComputeL(t *testing.T) {
 	u := big.NewInt(21)
 	n := big.NewInt(3)
-	exp := big.NewInt(6)
-	if !reflect.DeepEqual(exp, L(u, n)) {
-		t.Error("L function is not good")
+
+	expected := big.NewInt(6)
+	actual := L(u, n)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected L function result [%v]", actual)
 	}
 }
 
-func TestComputeMu(t *testing.T) {
-	p := big.NewInt(13)
-	q := big.NewInt(11)
-
-	lambda := computeLamda(p, q)
-	g := big.NewInt(5000)
-	n := new(big.Int).Mul(p, q)
-
-	exp := big.NewInt(3)
-	if !reflect.DeepEqual(computeMu(g, lambda, n), exp) {
-		t.Error("mu is not well computed")
-	}
-}
-
-func TestComputeLambda(t *testing.T) {
+func TestComputePhi(t *testing.T) {
 	a := big.NewInt(5)
 	b := big.NewInt(7)
-	expected := big.NewInt(12)
 
-	if !reflect.DeepEqual(expected, computeLamda(a, b)) {
-		t.Error("lambda is not correctly computed")
+	expected := big.NewInt(24)
+	actual := computePhi(a, b)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected phi value [%v]", actual)
+	}
+}
+
+func TestCreatePrivateKey(t *testing.T) {
+	p := big.NewInt(463)
+	q := big.NewInt(631)
+
+	privateKey := CreatePrivateKey(p, q)
+
+	if !reflect.DeepEqual(privateKey.N, big.NewInt(292153)) {
+		t.Errorf("Unexpected N PublicKey value [%v]", privateKey.N)
+	}
+
+	if !reflect.DeepEqual(privateKey.Lambda, big.NewInt(291060)) {
+		t.Errorf("Unexpected Lambda Public key value [%v]", privateKey.Lambda)
 	}
 }
 
@@ -63,10 +59,9 @@ func TestEncryptDecryptSmall(t *testing.T) {
 		}
 		returnedValue := privateKey.Decrypt(cypher)
 		if !reflect.DeepEqual(inicialValue, returnedValue) {
-			t.Error("wrond decryption ", returnedValue, " is not ", inicialValue)
+			t.Error("wrong decryption ", returnedValue, " is not ", inicialValue)
 		}
 	}
-
 }
 
 func TestAddCypher(t *testing.T) {

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -14,6 +14,7 @@ type ThresholdKey struct {
 	Threshold                      int
 	V                              *big.Int
 	Vi                             []*big.Int
+	G                              *big.Int
 }
 
 // returns the value of (4*delta**2)** -1  mod n

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -79,6 +79,16 @@ func (this *ThresholdKey) computeLambda(share *PartialDecryption, shares []*Part
 	return lambda
 }
 
+// Used to evaluate c' parameter which combines individual share decryptions.
+//
+// Modulo division is performed on the computed exponent to avoid creating
+// large numbers. This is possible because of the following property of modulo:
+// A^B mod C = (A mod C)^B mod C
+//
+// Modulo division is performed on the computed coefficient because of the
+// following property of modulo:
+// (AB) mod C = (A mod C * B mod C) mod C
+// Note, we need to combine coefficients into single c'.
 func (this *ThresholdKey) updateCprime(cprime, lambda *big.Int, share *PartialDecryption) *big.Int {
 	twoLambda := new(big.Int).Mul(TWO, lambda)
 	ret := this.exp(share.Decryption, twoLambda, this.GetNSquare())
@@ -154,13 +164,17 @@ func (this *ThresholdKey) VerifyDecryption(encryptedMessage, decryptedMessage *b
 	return nil
 }
 
+// Private key for a threshold Paillier scheme. Holds private information
+// for the given decryption server.
+// `Id` is the unique identifier of a decryption server and `Share` is a secret
+// share generated from hiding polynomial and is used for a partial share decryption.
 type ThresholdPrivateKey struct {
 	ThresholdKey
 	Id    int
 	Share *big.Int
 }
 
-//  Decrypt the cypher text and returns the partial decryption
+// Decrypts the cypher text and returns the partial decryption
 func (this *ThresholdPrivateKey) Decrypt(c *big.Int) *PartialDecryption {
 	ret := new(PartialDecryption)
 	ret.Id = this.Id
@@ -264,7 +278,6 @@ type PartialDecryptionZKP struct {
 	E   *big.Int      // the challenge
 	Z   *big.Int      // the value needed to check to verify the decryption
 	C   *big.Int      // the input cypher text
-
 }
 
 func (this *PartialDecryptionZKP) verifyPart1() *big.Int {

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -97,8 +97,14 @@ func (tk *ThresholdPublicKey) updateCprime(cprime, lambda *big.Int, share *Parti
 	return new(big.Int).Mod(ret, tk.GetNSquare())
 }
 
+// We use `exp` from `updateCprime` to raise decryption share to the power of lambda
+// parameter. Since lambda can be a negative number and we do discrete math here,
+// we need to apply multiplicative inverse modulo in this case.
+//
+// For instance, for b = -18:
+// b^{−18} = (b^−1)^18, where b^{−1} is the multiplicative inverse modulo c.
 func (tk *ThresholdPublicKey) exp(a, b, c *big.Int) *big.Int {
-	if b.Cmp(ZERO) == -1 {
+	if b.Cmp(ZERO) == -1 { // b < 0 ?
 		ret := new(big.Int).Exp(a, new(big.Int).Neg(b), c)
 		return new(big.Int).ModInverse(ret, c)
 	}

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -48,7 +48,7 @@ func (tk *ThresholdPublicKey) delta() *big.Int {
 // Checks if the number of received, unique shares is less than the
 // required threshold.
 // This method does not execute ZKP on received shares.
-func (tk *ThresholdPublicKey) makeVerificationBeforeCombiningPartialDecryptions(shares []*PartialDecryption) error {
+func (tk *ThresholdPublicKey) verifyPartialDecryptions(shares []*PartialDecryption) error {
 	if len(shares) < tk.Threshold {
 		return errors.New("Threshold not meet")
 	}
@@ -118,7 +118,7 @@ func (tk *ThresholdPublicKey) computeDecryption(cprime *big.Int) *big.Int {
 // This function does not verify zero knowledge proofs. Returned message can be
 // incorrectly decrypted if an adversary corrupted partial decryption.
 func (tk *ThresholdPublicKey) CombinePartialDecryptions(shares []*PartialDecryption) (*big.Int, error) {
-	if err := tk.makeVerificationBeforeCombiningPartialDecryptions(shares); err != nil {
+	if err := tk.verifyPartialDecryptions(shares); err != nil {
 		return nil, err
 	}
 
@@ -131,8 +131,8 @@ func (tk *ThresholdPublicKey) CombinePartialDecryptions(shares []*PartialDecrypt
 	return tk.computeDecryption(cprime), nil
 }
 
-// Combines partial decryptions provided by decription servers and returns
-// decrypted message.
+// Combines partial decryptions provided by decryption servers and returns
+// full decrypted message.
 // Function verifies zero knowledge proofs and filters out all shares that failed
 // verification.
 func (tk *ThresholdPublicKey) CombinePartialDecryptionsZKP(shares []*PartialDecryptionZKP) (*big.Int, error) {

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -86,24 +86,12 @@ func (this *ThresholdKey) updateCprime(cprime, lambda *big.Int, share *PartialDe
 	return new(big.Int).Mod(ret, this.GetNSquare())
 }
 
-// TODO: unused? kill?
-func (this *ThresholdKey) divide(a, b *big.Int) *big.Int {
-	if a.Cmp(ZERO) == -1 {
-		if b.Cmp(ZERO) == -1 {
-			return new(big.Int).Div(new(big.Int).Neg(a), new(big.Int).Neg(b))
-		}
-		return new(big.Int).Neg(new(big.Int).Div(new(big.Int).Neg(a), b))
-	}
-	return new(big.Int).Div(a, b)
-}
-
 func (this *ThresholdKey) exp(a, b, c *big.Int) *big.Int {
 	if b.Cmp(ZERO) == -1 {
 		ret := new(big.Int).Exp(a, new(big.Int).Neg(b), c)
 		return new(big.Int).ModInverse(ret, c)
 	}
 	return new(big.Int).Exp(a, b, c)
-
 }
 
 // Executes the last step of message decryption. Takes `cprime` value computed
@@ -146,11 +134,10 @@ func (this *ThresholdKey) CombinePartialDecryptionsZKP(shares []*PartialDecrypti
 	return this.CombinePartialDecryptions(ret)
 }
 
-//  Verify if the decryption of `encryptedMessage` has well been done.
-//  It verifies all the zero-knoledge proofs, the value of the decrypted
-//  and decrypted message.
-//  The method returns `nil` if everything is good.  Otherwise it returns an
-//  explicative message
+// Verifies if the decryption of `encryptedMessage` has been done properly.
+// It verifies all the zero-knoledge proofs, the value of the decrypted
+// and decrypted message. The method returns `nil` if everything is fine.
+// Otherwise, it returns an explicative message.
 func (this *ThresholdKey) VerifyDecryption(encryptedMessage, decryptedMessage *big.Int, shares []*PartialDecryptionZKP) error {
 	for _, share := range shares {
 		if share.C.Cmp(encryptedMessage) != 0 {

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -331,37 +331,37 @@ type PartialDecryptionZKP struct {
 	C   *big.Int      // the input cypher text
 }
 
-func (this *PartialDecryptionZKP) verifyPart1() *big.Int {
-	c4 := new(big.Int).Exp(this.C, FOUR, nil)                  // c^4
-	decryption2 := new(big.Int).Exp(this.Decryption, TWO, nil) // c_i^2
+func (pd *PartialDecryptionZKP) verifyPart1() *big.Int {
+	c4 := new(big.Int).Exp(pd.C, FOUR, nil)                  // c^4
+	decryption2 := new(big.Int).Exp(pd.Decryption, TWO, nil) // c_i^2
 
-	a1 := new(big.Int).Exp(c4, this.Z, this.Key.GetNSquare())          // (c^4)^Z
-	a2 := new(big.Int).Exp(decryption2, this.E, this.Key.GetNSquare()) // (c_i^2)^E
-	a2 = new(big.Int).ModInverse(a2, this.Key.GetNSquare())
-	a := new(big.Int).Mod(new(big.Int).Mul(a1, a2), this.Key.GetNSquare())
+	a1 := new(big.Int).Exp(c4, pd.Z, pd.Key.GetNSquare())          // (c^4)^Z
+	a2 := new(big.Int).Exp(decryption2, pd.E, pd.Key.GetNSquare()) // (c_i^2)^E
+	a2 = new(big.Int).ModInverse(a2, pd.Key.GetNSquare())
+	a := new(big.Int).Mod(new(big.Int).Mul(a1, a2), pd.Key.GetNSquare())
 	return a
 }
 
-func (this *PartialDecryptionZKP) verifyPart2() *big.Int {
-	vi := this.Key.Vi[this.Id-1]                                      // servers are indexed from 1
-	b1 := new(big.Int).Exp(this.Key.V, this.Z, this.Key.GetNSquare()) // V^Z
-	b2 := new(big.Int).Exp(vi, this.E, this.Key.GetNSquare())         // (v_i)^E
-	b2 = new(big.Int).ModInverse(b2, this.Key.GetNSquare())
-	b := new(big.Int).Mod(new(big.Int).Mul(b1, b2), this.Key.GetNSquare())
+func (pd *PartialDecryptionZKP) verifyPart2() *big.Int {
+	vi := pd.Key.Vi[pd.Id-1]                                    // servers are indexed from 1
+	b1 := new(big.Int).Exp(pd.Key.V, pd.Z, pd.Key.GetNSquare()) // V^Z
+	b2 := new(big.Int).Exp(vi, pd.E, pd.Key.GetNSquare())       // (v_i)^E
+	b2 = new(big.Int).ModInverse(b2, pd.Key.GetNSquare())
+	b := new(big.Int).Mod(new(big.Int).Mul(b1, b2), pd.Key.GetNSquare())
 	return b
 }
 
-func (this *PartialDecryptionZKP) Verify() bool {
-	a := this.verifyPart1()
-	b := this.verifyPart2()
+func (pd *PartialDecryptionZKP) Verify() bool {
+	a := pd.verifyPart1()
+	b := pd.verifyPart2()
 	hash := sha256.New()
 	hash.Write(a.Bytes())
 	hash.Write(b.Bytes())
-	c4 := new(big.Int).Exp(this.C, FOUR, nil)
+	c4 := new(big.Int).Exp(pd.C, FOUR, nil)
 	hash.Write(c4.Bytes())
-	ci2 := new(big.Int).Exp(this.Decryption, TWO, nil)
+	ci2 := new(big.Int).Exp(pd.Decryption, TWO, nil)
 	hash.Write(ci2.Bytes())
 
 	expectedE := new(big.Int).SetBytes(hash.Sum([]byte{}))
-	return this.E.Cmp(expectedE) == 0
+	return pd.E.Cmp(expectedE) == 0
 }

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -14,7 +14,6 @@ type ThresholdKey struct {
 	Threshold                      int
 	V                              *big.Int
 	Vi                             []*big.Int
-	G                              *big.Int // usually G is set to N+1
 }
 
 // returns the value of (4*delta**2)** -1  mod n
@@ -165,7 +164,6 @@ func (this *ThresholdPrivateKey) GetThresholdKey() *ThresholdKey {
 	ret.V = new(big.Int).Add(this.V, big.NewInt(0))
 	ret.Vi = this.copyVi()
 	ret.N = new(big.Int).Add(this.N, big.NewInt(0))
-	ret.G = new(big.Int).Add(this.N, big.NewInt(1))
 	return ret
 }
 

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -278,16 +278,29 @@ type PartialDecryption struct {
 // (`ThresholdPrivateKey.Share`) by comparison with the public verification key
 // (`ThresholdKey.Vi`). Recall that v_i = v^(delta s_i).
 //
+// The Fiat-Shamir is a non-interactive proof of knowledge heuristic.
+// The general algorithm is as follows:
+//
+// - Alice wants to prove that she knows x: the discrete logarithm of y = g^x
+//   to the base g
+// - Alice picks a random r from Z_q and computes t = g^r
+// - Alice computes E = H(t, g, y), where H is a cryptographic hash function
+// - Alice computes Z = Ex + r.
+//   The resulting proof is the pair (t, Z).
+// - Anyone can check whether t = g^Z y^E (mod q)
+//
+// In our case:
+//
+// Decryption server i wants to prove that he indeed raised the cyphertext to
+// his secret exponent s_i during partial decryption.
 // This is essentialy a protocol for the equality of discrete logs,
 // log_{c^4}(c_i^2) = log_v(v_i).
 //
-// The Fiat-Shamir scheme works as follows in our case:
-//
 // ZKP construction
 //
-// - Pick random r
+// - Pick random r mod n
 // - Compute E as:
-//   E = HASH(a, b, c^4, c_i^2 ), where
+//   E = HASH(a, b, c^4, c_i^2), where
 //     a = (c^4)^r mod n^2
 //     b = V^r mod n^2
 //     c is a cyphertext,
@@ -308,7 +321,7 @@ type PartialDecryption struct {
 //   b = b1 * b2 mod n^2
 //   b1 = V^Z
 //   b2 = [ v_i^E ] -1 mod n^2
-// - Rehash H(a, b, c^4, c_i)
+// - Rehash H(a, b, c^4, c_i^2)
 // - Compare ZKP hash with the one just computed
 type PartialDecryptionZKP struct {
 	PartialDecryption

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -14,7 +14,7 @@ type ThresholdKey struct {
 	Threshold                      int
 	V                              *big.Int
 	Vi                             []*big.Int
-	G                              *big.Int
+	G                              *big.Int // usually G is set to N+1
 }
 
 // returns the value of (4*delta**2)** -1  mod n

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -101,8 +101,31 @@ func (this *ThresholdKeyGenerator) ComputeV() error {
 	return err
 }
 
-// Choose d such that d=0 mod m and d=1 mod n, using Chinese remainder thm
-// we can find d using Chinese remainder thm note that $d=(m. (m^-1 mod n))$
+// Choose d such that d=0 (mod m) and d=1 (mod n).
+// See [DJN 10], section 5.1, "Key generation"
+//
+// From Chinese Remainder Theorem:
+// x = a1 (mod n1)
+// x = a2 (mod n2)
+//
+// N = n1*n2
+// y1 = N/n1
+// y2 = N/n2
+// z1 = y1^-1 mod n1
+// z2 = y2^-1 mod n2
+// Solution is x = a1*y1*z1 + a2*y2*z2
+//
+// In our case:
+// x = 0 (mod m)
+// x = 1 (mod n)
+//
+// Since a1 = 0, it's enough to compute a2*y2*z2 to get x.
+//
+// a2 = 1
+// y2 = mn/n = m
+// z2 = m^-1 mod n
+//
+// x = a2*y2*z2 = 1 * m * [m^-1 mod n]
 func (this *ThresholdKeyGenerator) InitD() {
 	mInverse := new(big.Int).ModInverse(this.m, this.n)
 	this.d = new(big.Int).Mul(mInverse, this.m)

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -219,7 +219,6 @@ func (this *ThresholdKeyGenerator) createViArray(shares []*big.Int) (viArray []*
 func (this *ThresholdKeyGenerator) createPrivateKey(i int, share *big.Int, viArray []*big.Int) *ThresholdPrivateKey {
 	ret := new(ThresholdPrivateKey)
 	ret.N = this.n
-	ret.G = new(big.Int).Add(ret.N, ONE)
 	ret.V = this.v
 
 	ret.TotalNumberOfDecryptionServers = this.TotalNumberOfDecryptionServers

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -6,21 +6,32 @@ import (
 	"math/big"
 )
 
+// Generates a threshold Paillier key with an algorithm based on [DJN 10],
+// section 5.1, "Key generation".
+//
+// Bear in mind that the algorithm assumes an existence of a trusted dealer
+// to generate and distribute the keys.
+//
+//
+//     [DJN 10]: Ivan Damgard, Mads Jurik, Jesper Buus Nielsen, (2010)
+//               A Generalization of Paillier’s Public-Key System
+//               with Applications to Electronic Voting
+//               Aarhus University, Dept. of Computer Science, BRICS
 type ThresholdKeyGenerator struct {
 	nbits                          int
 	TotalNumberOfDecryptionServers int
 	Threshold                      int
 	Random                         io.Reader
 
-	//Both p1 and q1 are primes of length nbits - 1
+	// Both p1 and q1 are primes of length nbits - 1
 	p1 *big.Int
 	q1 *big.Int
 
-	p       *big.Int //p is prime and p=2*p1+1
-	q       *big.Int //q is prime and q=2*q1+1
+	p       *big.Int // p is prime and p=2*p1+1
+	q       *big.Int // q is prime and q=2*q1+1
 	n       *big.Int // n=p*q
-	m       *big.Int //m = p1*q1
-	nSquare *big.Int //nSquare = n*n
+	m       *big.Int // m = p1*q1
+	nSquare *big.Int // nSquare = n*n
 	nm      *big.Int // nm = n*m
 
 	// As specified in the paper, d must satify d=1 mod n and d=0 mod m
@@ -29,13 +40,14 @@ type ThresholdKeyGenerator struct {
 	// A generator of QR in Z_{n^2}
 	v *big.Int
 
-	// the polynomial coefficients to hide a secret.  See Shamir.
+	// The polynomial coefficients to hide a secret. See Shamir.
 	polynomialCoefficients []*big.Int
 }
 
-//  preferable way to counstruct the ThresholdKeyGenerator.  No verification
-//  is done on the input values.  You need to bu sure that nbits is big enough
-//  and that Threshold > TotalNumberOfDecryptionServers / 2
+// Preferable way to construct the ThresholdKeyGenerator.  No verification
+// is done on the input values.  You need to be sure that nbits is big enough
+// and that Threshold > TotalNumberOfDecryptionServers / 2.
+// The plaintext space for the key will be Z_n.
 func GetThresholdKeyGenerator(nbits, TotalNumberOfDecryptionServers, Threshold int, random io.Reader) *ThresholdKeyGenerator {
 	ret := new(ThresholdKeyGenerator)
 	ret.nbits = nbits
@@ -95,6 +107,7 @@ func (this *ThresholdKeyGenerator) InitPsAndQs() error {
 	return nil
 }
 
+// v generates a cyclic group of squares in Zn^2.
 func (this *ThresholdKeyGenerator) ComputeV() error {
 	var err error
 	this.v, err = GetRandomGeneratorOfTheQuadraticResidue(this.nSquare, this.Random)
@@ -102,7 +115,6 @@ func (this *ThresholdKeyGenerator) ComputeV() error {
 }
 
 // Choose d such that d=0 (mod m) and d=1 (mod n).
-// See [DJN 10], section 5.1, "Key generation"
 //
 // From Chinese Remainder Theorem:
 // x = a1 (mod n1)
@@ -140,6 +152,12 @@ func (this *ThresholdKeyGenerator) InitNumerialValues() error {
 	return this.ComputeV()
 }
 
+// f(X) = a_0 X^0 + a_1 X^1 + ... + a_(w-1) X^(w-1)
+//
+// where:
+// `w` - threshold
+// `a_i` - random value from {0, ... nm - 1} for 0<i<w
+// `a_0` is always equal `d`
 func (this *ThresholdKeyGenerator) GenerateHidingPolynomial() error {
 	this.polynomialCoefficients = make([]*big.Int, this.Threshold)
 	this.polynomialCoefficients[0] = this.d
@@ -153,6 +171,8 @@ func (this *ThresholdKeyGenerator) GenerateHidingPolynomial() error {
 	return nil
 }
 
+// The secred share of the i'th authority is `f(i)`, where `f` is
+// the polynomial we generated in `GenerateHidingPolynomial` function.
 func (this *ThresholdKeyGenerator) ComputeShare(index int) *big.Int {
 	share := big.NewInt(0)
 	for i := 0; i < this.Threshold; i++ {
@@ -176,6 +196,15 @@ func (this *ThresholdKeyGenerator) Delta() *big.Int {
 	return Factorial(this.TotalNumberOfDecryptionServers)
 }
 
+// Generates verification keys for actions of decryption servers.
+//
+// For each decryption server `i`, we generate
+// v_i = v^(l! s_i) mod n^2
+//
+// where:
+// `l` is the number of decryption servers
+// `s_i` is a secret share for server `i`.
+// Secret shares were previously generated in the `CrateShares` function.
 func (this *ThresholdKeyGenerator) CreateViArray(shares []*big.Int) (viArray []*big.Int) {
 	viArray = make([]*big.Int, len(shares))
 	delta := this.Delta()

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -171,12 +171,13 @@ func (this *ThresholdKeyGenerator) generateHidingPolynomial() error {
 	return nil
 }
 
-// The secred share of the i'th authority is `f(i)`, where `f` is
+// The secred share of the i'th authority is `f(i) mod nm`, where `f` is
 // the polynomial we generated in `GenerateHidingPolynomial` function.
 func (this *ThresholdKeyGenerator) computeShare(index int) *big.Int {
 	share := big.NewInt(0)
 	for i := 0; i < this.Threshold; i++ {
 		a := this.polynomialCoefficients[i]
+		// we index authorities from 1, that's why we do index+1 here
 		b := new(big.Int).Exp(big.NewInt(int64(index+1)), big.NewInt(int64(i)), nil)
 		tmp := new(big.Int).Mul(a, b)
 		share = new(big.Int).Add(share, tmp)

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -15,7 +15,7 @@ func TestGenerateSafePrimesOfThresholdKeyGenerator(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
 	tkh.nbits = 10
 	tkh.Random = rand.Reader
-	p, q, err := tkh.GenerateSafePrimes()
+	p, q, err := tkh.generateSafePrimes()
 	if err != nil {
 		t.Error(err)
 		return
@@ -29,7 +29,7 @@ func TestInitPandP1(t *testing.T) {
 	tkh.nbits = 10
 	tkh.Random = rand.Reader
 
-	tkh.InitPandP1()
+	tkh.initPandP1()
 	AreSafePrimes(tkh.p, tkh.p1, 10, t)
 
 }
@@ -39,7 +39,7 @@ func TestInitQandQ1(t *testing.T) {
 	tkh.nbits = 10
 	tkh.Random = rand.Reader
 
-	tkh.InitQandQ1()
+	tkh.initQandQ1()
 	AreSafePrimes(tkh.q, tkh.q1, 10, t)
 }
 
@@ -48,7 +48,7 @@ func TestInitPsAndQs(t *testing.T) {
 	tkh.nbits = 10
 	tkh.Random = rand.Reader
 
-	tkh.InitPsAndQs()
+	tkh.initPsAndQs()
 	AreSafePrimes(tkh.q, tkh.q1, 10, t)
 	AreSafePrimes(tkh.q, tkh.q1, 10, t)
 }
@@ -56,17 +56,17 @@ func TestInitPsAndQs(t *testing.T) {
 func TestArePsAndQsGood(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
 	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(6), b(5), b(4), b(3)
-	if !tkh.ArePsAndQsGood() {
+	if !tkh.arePsAndQsGood() {
 		t.Fail()
 	}
 
 	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(6), b(5), b(6), b(3)
-	if tkh.ArePsAndQsGood() {
+	if tkh.arePsAndQsGood() {
 		t.Fail()
 	}
 
 	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(6), b(5), b(5), b(3)
-	if tkh.ArePsAndQsGood() {
+	if tkh.arePsAndQsGood() {
 		t.Fail()
 	}
 }
@@ -74,7 +74,7 @@ func TestArePsAndQsGood(t *testing.T) {
 func TestInitShortcuts(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
 	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(11), b(7), b(5), b(3)
-	tkh.InitShortcuts()
+	tkh.initShortcuts()
 
 	if n(tkh.n) != 11*5 {
 		t.Error("wrong n", tkh.n)
@@ -93,8 +93,8 @@ func TestInitShortcuts(t *testing.T) {
 func TestInitD(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
 	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(863), b(431), b(839), b(419)
-	tkh.InitShortcuts()
-	tkh.InitD()
+	tkh.initShortcuts()
+	tkh.initD()
 	if n(tkh.d)%n(tkh.m) != 0 {
 		t.Fail()
 	}
@@ -108,7 +108,7 @@ func TestInitNumerialValues(t *testing.T) {
 	tkh.nbits = 10
 	tkh.Random = rand.Reader
 
-	if err := tkh.InitNumerialValues(); err != nil {
+	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
 	}
 }
@@ -118,11 +118,11 @@ func TestGenerateHidingPolynomial(t *testing.T) {
 	tkh.nbits = 10
 	tkh.Threshold = 10
 	tkh.Random = rand.Reader
-	if err := tkh.InitNumerialValues(); err != nil {
+	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
 		return
 	}
-	if err := tkh.GenerateHidingPolynomial(); err != nil {
+	if err := tkh.generateHidingPolynomial(); err != nil {
 		t.Error(err)
 	}
 	p := tkh.polynomialCoefficients
@@ -147,7 +147,7 @@ func TestComputeShare(t *testing.T) {
 	tkh.TotalNumberOfDecryptionServers = 5
 	tkh.nm = b(103)
 	tkh.polynomialCoefficients = []*big.Int{b(29), b(88), b(51)}
-	share := tkh.ComputeShare(2)
+	share := tkh.computeShare(2)
 	if n(share) != 31 {
 		t.Error("error computing a share.  ", share)
 	}
@@ -159,16 +159,16 @@ func TestCreateShares(t *testing.T) {
 	tkh.Threshold = 10
 	tkh.TotalNumberOfDecryptionServers = 100
 	tkh.Random = rand.Reader
-	if err := tkh.InitNumerialValues(); err != nil {
+	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
 		return
 	}
-	if err := tkh.GenerateHidingPolynomial(); err != nil {
+	if err := tkh.generateHidingPolynomial(); err != nil {
 		t.Error(err)
 		return
 	}
 
-	if shares := tkh.CreateShares(); len(shares) != 100 {
+	if shares := tkh.createShares(); len(shares) != 100 {
 		t.Fail()
 	}
 }
@@ -178,7 +178,7 @@ func TestCreateViArray(t *testing.T) {
 	tkh.TotalNumberOfDecryptionServers = 10
 	tkh.v = b(54)
 	tkh.nSquare = b(101 * 101)
-	vArr := tkh.CreateViArray([]*big.Int{b(12), b(90), b(103)})
+	vArr := tkh.createViArray([]*big.Int{b(12), b(90), b(103)})
 	exp := []*big.Int{b(6162), b(304), b(2728)}
 	if !reflect.DeepEqual(vArr, exp) {
 		t.Fail()
@@ -187,7 +187,7 @@ func TestCreateViArray(t *testing.T) {
 
 func TestGetThresholdKeyGenerator(t *testing.T) {
 	tkh := GetThresholdKeyGenerator(50, 10, 6, rand.Reader)
-	if err := tkh.InitNumerialValues(); err != nil {
+	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(nil)
 	}
 }
@@ -223,7 +223,7 @@ func TestComputeV(t *testing.T) {
 	tkh.n = b(1907 * 1823)
 	tkh.nSquare = new(big.Int).Mul(tkh.n, tkh.n)
 	for i := 0; i < 100; i++ {
-		if err := tkh.ComputeV(); err != nil {
+		if err := tkh.computeV(); err != nil {
 			t.Error(err)
 			return
 		}

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -207,7 +207,7 @@ func TestGenerate(t *testing.T) {
 		if len(tpk.Vi) != 10 {
 			t.Fail()
 		}
-		if tpk.G == nil || tpk.N == nil {
+		if tpk.N == nil {
 			t.Fail()
 		}
 		if tpk.Threshold != 6 || tpk.TotalNumberOfDecryptionServers != 10 {

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -118,7 +118,6 @@ func TestGenerateHidingPolynomial(t *testing.T) {
 	tkh.Random = rand.Reader
 	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
-		return
 	}
 	if err := tkh.generateHidingPolynomial(); err != nil {
 		t.Error(err)
@@ -126,7 +125,6 @@ func TestGenerateHidingPolynomial(t *testing.T) {
 	p := tkh.polynomialCoefficients
 	if len(p) != tkh.Threshold {
 		t.Fail()
-		return
 	}
 	if n(p[0]) != n(tkh.d) {
 		t.Fail()
@@ -159,11 +157,9 @@ func TestCreateShares(t *testing.T) {
 	tkh.Random = rand.Reader
 	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
-		return
 	}
 	if err := tkh.generateHidingPolynomial(); err != nil {
 		t.Error(err)
-		return
 	}
 
 	if shares := tkh.createShares(); len(shares) != 100 {
@@ -223,7 +219,6 @@ func TestComputeV(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		if err := tkh.computeV(); err != nil {
 			t.Error(err)
-			return
 		}
 		if tkh.v.Cmp(tkh.nSquare) > 0 {
 			t.Error("v is too big")
@@ -235,5 +230,4 @@ func TestComputeV(t *testing.T) {
 	t.Error(`v has never been bigger than n.  It is suspicious in the sense<
 	than it was taken in the range 0...n**2 -1
 	`)
-
 }

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -18,10 +18,8 @@ func TestGenerateSafePrimesOfThresholdKeyGenerator(t *testing.T) {
 	p, q, err := tkh.generateSafePrimes()
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	AreSafePrimes(p, q, 10, t)
-
 }
 
 func TestInitPandP1(t *testing.T) {
@@ -31,7 +29,6 @@ func TestInitPandP1(t *testing.T) {
 
 	tkh.initPandP1()
 	AreSafePrimes(tkh.p, tkh.p1, 10, t)
-
 }
 
 func TestInitQandQ1(t *testing.T) {
@@ -49,23 +46,24 @@ func TestInitPsAndQs(t *testing.T) {
 	tkh.Random = rand.Reader
 
 	tkh.initPsAndQs()
-	AreSafePrimes(tkh.q, tkh.q1, 10, t)
+
+	AreSafePrimes(tkh.p, tkh.p1, 10, t)
 	AreSafePrimes(tkh.q, tkh.q1, 10, t)
 }
 
 func TestArePsAndQsGood(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(6), b(5), b(4), b(3)
+	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(887), b(443), b(839), b(419)
 	if !tkh.arePsAndQsGood() {
 		t.Fail()
 	}
 
-	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(6), b(5), b(6), b(3)
+	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(887), b(443), b(887), b(443)
 	if tkh.arePsAndQsGood() {
 		t.Fail()
 	}
 
-	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(6), b(5), b(5), b(3)
+	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(887), b(443), b(443), b(221)
 	if tkh.arePsAndQsGood() {
 		t.Fail()
 	}
@@ -73,19 +71,19 @@ func TestArePsAndQsGood(t *testing.T) {
 
 func TestInitShortcuts(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(11), b(7), b(5), b(3)
+	tkh.p, tkh.p1, tkh.q, tkh.q1 = b(839), b(419), b(887), b(443)
 	tkh.initShortcuts()
 
-	if n(tkh.n) != 11*5 {
+	if !reflect.DeepEqual(tkh.n, b(744193)) {
 		t.Error("wrong n", tkh.n)
 	}
-	if n(tkh.m) != 7*3 {
+	if !reflect.DeepEqual(tkh.m, b(185617)) {
 		t.Error("wrong m", tkh.m)
 	}
-	if n(tkh.nm) != 11*5*7*3 {
+	if !reflect.DeepEqual(tkh.nm, new(big.Int).Mul(b(744193), b(185617))) {
 		t.Error("wrong nm", tkh.nm)
 	}
-	if n(tkh.nSquare) != 11*5*11*5 {
+	if !reflect.DeepEqual(tkh.nSquare, new(big.Int).Mul(b(744193), b(744193))) {
 		t.Error("wrong nSquare", tkh.nSquare)
 	}
 }

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func GetThresholdPrivateKey() *ThresholdPrivateKey {
+func getThresholdPrivateKey() *ThresholdPrivateKey {
 	tkh := GetThresholdKeyGenerator(32, 10, 6, rand.Reader)
 	tpks, err := tkh.Generate()
 	if err != nil {
@@ -19,7 +19,7 @@ func GetThresholdPrivateKey() *ThresholdPrivateKey {
 func TestDelta(t *testing.T) {
 	tk := new(ThresholdKey)
 	tk.TotalNumberOfDecryptionServers = 6
-	if delta := tk.Delta(); 720 != n(delta) {
+	if delta := tk.delta(); 720 != n(delta) {
 		t.Error("Delta is not 720 but", delta)
 	}
 }
@@ -29,7 +29,7 @@ func TestCombineSharesConstant(t *testing.T) {
 	tk.N = big.NewInt(101 * 103)
 	tk.TotalNumberOfDecryptionServers = 6
 
-	if c := tk.CombineSharesConstant(); !reflect.DeepEqual(big.NewInt(4558), c) {
+	if c := tk.combineSharesConstant(); !reflect.DeepEqual(big.NewInt(4558), c) {
 		t.Error("wrong combined key.  ", c)
 	}
 }
@@ -66,7 +66,7 @@ func TestCopyVi(t *testing.T) {
 }
 
 func TestEncryptWithThresholdKey(t *testing.T) {
-	pd := GetThresholdPrivateKey()
+	pd := getThresholdPrivateKey()
 	_, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Fail()
@@ -74,7 +74,7 @@ func TestEncryptWithThresholdKey(t *testing.T) {
 }
 
 func TestDecryptWithThresholdKey(t *testing.T) {
-	pd := GetThresholdPrivateKey()
+	pd := getThresholdPrivateKey()
 	c, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Fail()
@@ -111,7 +111,7 @@ func TestVerifyPart2(t *testing.T) {
 }
 
 func TestDecryptAndProduceZNP(t *testing.T) {
-	pd := GetThresholdPrivateKey()
+	pd := getThresholdPrivateKey()
 	c, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Error(err)
@@ -131,16 +131,16 @@ func TestDecryptAndProduceZNP(t *testing.T) {
 func TestMakeVerificationBeforeCombiningPartialDecryptions(t *testing.T) {
 	tk := new(ThresholdKey)
 	tk.Threshold = 2
-	if tk.MakeVerificationBeforeCombiningPartialDecryptions([]*PartialDecryption{}) == nil {
+	if tk.makeVerificationBeforeCombiningPartialDecryptions([]*PartialDecryption{}) == nil {
 		t.Fail()
 	}
 	prms := []*PartialDecryption{new(PartialDecryption), new(PartialDecryption)}
 	prms[1].Id = 1
-	if tk.MakeVerificationBeforeCombiningPartialDecryptions(prms) != nil {
+	if tk.makeVerificationBeforeCombiningPartialDecryptions(prms) != nil {
 		t.Fail()
 	}
 	prms[1].Id = 0
-	if tk.MakeVerificationBeforeCombiningPartialDecryptions(prms) == nil {
+	if tk.makeVerificationBeforeCombiningPartialDecryptions(prms) == nil {
 		t.Fail()
 	}
 }
@@ -150,7 +150,7 @@ func TestUpdateLambda(t *testing.T) {
 	lambda := b(11)
 	share1 := &PartialDecryption{3, b(5)}
 	share2 := &PartialDecryption{7, b(3)}
-	res := tk.UpdateLambda(share1, share2, lambda)
+	res := tk.updateLambda(share1, share2, lambda)
 	if n(res) != 20 {
 		t.Error("wrong lambda", n(res))
 	}
@@ -250,7 +250,7 @@ func TestDivide(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	pk := GetThresholdPrivateKey()
+	pk := getThresholdPrivateKey()
 	if err := pk.Validate(rand.Reader); err != nil {
 		t.Error(err)
 	}

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -230,23 +230,6 @@ func TestDecryption(t *testing.T) {
 	} else if n(msg) != 100 {
 		t.Error("decrypted message was not 100 but ", msg)
 	}
-
-}
-
-func TestDivide(t *testing.T) {
-	tk := new(ThresholdKey)
-	if r := tk.divide(b(77), b(4)); n(r) != 19 {
-		t.Error("77 / 4 != 19 ( ", r, " )")
-	}
-	if r := tk.divide(b(-77), b(-4)); n(r) != 19 {
-		t.Error("-77 / -4 != 19 ( ", r, " )")
-	}
-	if r := tk.divide(b(-77), b(4)); n(r) != -19 {
-		t.Error("-77 / 4 != -19 ( ", r, " )")
-	}
-	if r := tk.divide(b(77), b(-4)); n(r) != -19 {
-		t.Error("77 / -4 != -19 ( ", r, " )")
-	}
 }
 
 func TestValidate(t *testing.T) {

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -129,16 +129,16 @@ func TestDecryptAndProduceZNP(t *testing.T) {
 func TestMakeVerificationBeforeCombiningPartialDecryptions(t *testing.T) {
 	tk := new(ThresholdPublicKey)
 	tk.Threshold = 2
-	if tk.makeVerificationBeforeCombiningPartialDecryptions([]*PartialDecryption{}) == nil {
+	if tk.verifyPartialDecryptions([]*PartialDecryption{}) == nil {
 		t.Fail()
 	}
 	prms := []*PartialDecryption{new(PartialDecryption), new(PartialDecryption)}
 	prms[1].Id = 1
-	if tk.makeVerificationBeforeCombiningPartialDecryptions(prms) != nil {
+	if tk.verifyPartialDecryptions(prms) != nil {
 		t.Fail()
 	}
 	prms[1].Id = 0
-	if tk.makeVerificationBeforeCombiningPartialDecryptions(prms) == nil {
+	if tk.verifyPartialDecryptions(prms) == nil {
 		t.Fail()
 	}
 }

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -224,7 +224,6 @@ func TestDecryption(t *testing.T) {
 	tk.Threshold = 2
 	tk.TotalNumberOfDecryptionServers = 2
 	tk.N = b(637753)
-	tk.G = b(637754)
 	tk.V = b(70661107826)
 	if msg, err := tk.CombinePartialDecryptions([]*PartialDecryption{share1, share2}); err != nil {
 		t.Error(err)

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -24,6 +24,22 @@ func TestDelta(t *testing.T) {
 	}
 }
 
+func TestExp(t *testing.T) {
+	tk := new(ThresholdPublicKey)
+
+	if exp := tk.exp(big.NewInt(720), big.NewInt(10), big.NewInt(49)); 43 != n(exp) {
+		t.Error("Unexpected exponent. Expected 43 but got", exp)
+	}
+
+	if exp := tk.exp(big.NewInt(720), big.NewInt(0), big.NewInt(49)); 1 != n(exp) {
+		t.Error("Unexpected exponent. Expected 0 but got", exp)
+	}
+
+	if exp := tk.exp(big.NewInt(720), big.NewInt(-10), big.NewInt(49)); 8 != n(exp) {
+		t.Error("Unexpected exponent. Expected 8 but got", exp)
+	}
+}
+
 func TestCombineSharesConstant(t *testing.T) {
 	tk := new(ThresholdPublicKey)
 	tk.N = big.NewInt(101 * 103)

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -17,7 +17,7 @@ func getThresholdPrivateKey() *ThresholdPrivateKey {
 }
 
 func TestDelta(t *testing.T) {
-	tk := new(ThresholdKey)
+	tk := new(ThresholdPublicKey)
 	tk.TotalNumberOfDecryptionServers = 6
 	if delta := tk.delta(); 720 != n(delta) {
 		t.Error("Delta is not 720 but", delta)
@@ -25,7 +25,7 @@ func TestDelta(t *testing.T) {
 }
 
 func TestCombineSharesConstant(t *testing.T) {
-	tk := new(ThresholdKey)
+	tk := new(ThresholdPublicKey)
 	tk.N = big.NewInt(101 * 103)
 	tk.TotalNumberOfDecryptionServers = 6
 
@@ -84,7 +84,7 @@ func TestDecryptWithThresholdKey(t *testing.T) {
 
 func TestVerifyPart1(t *testing.T) {
 	pd := new(PartialDecryptionZKP)
-	pd.Key = new(ThresholdKey)
+	pd.Key = new(ThresholdPublicKey)
 	pd.Key.N = b(131)
 	pd.Decryption = b(101)
 	pd.C = b(99)
@@ -98,7 +98,7 @@ func TestVerifyPart1(t *testing.T) {
 
 func TestVerifyPart2(t *testing.T) {
 	pd := new(PartialDecryptionZKP)
-	pd.Key = new(ThresholdKey)
+	pd.Key = new(ThresholdPublicKey)
 	pd.Id = 1
 	pd.Key.Vi = []*big.Int{b(77), b(67)} // vi is 67
 	pd.Key.N = b(131)
@@ -127,7 +127,7 @@ func TestDecryptAndProduceZNP(t *testing.T) {
 }
 
 func TestMakeVerificationBeforeCombiningPartialDecryptions(t *testing.T) {
-	tk := new(ThresholdKey)
+	tk := new(ThresholdPublicKey)
 	tk.Threshold = 2
 	if tk.makeVerificationBeforeCombiningPartialDecryptions([]*PartialDecryption{}) == nil {
 		t.Fail()
@@ -144,7 +144,7 @@ func TestMakeVerificationBeforeCombiningPartialDecryptions(t *testing.T) {
 }
 
 func TestUpdateLambda(t *testing.T) {
-	tk := new(ThresholdKey)
+	tk := new(ThresholdPublicKey)
 	lambda := b(11)
 	share1 := &PartialDecryption{3, b(5)}
 	share2 := &PartialDecryption{7, b(3)}
@@ -155,7 +155,7 @@ func TestUpdateLambda(t *testing.T) {
 }
 
 func TestupdateCprime(t *testing.T) {
-	tk := new(ThresholdKey)
+	tk := new(ThresholdPublicKey)
 	tk.N = b(99)
 	cprime := b(77)
 	lambda := b(52)
@@ -238,7 +238,7 @@ func TestDecryption(t *testing.T) {
 	// test the correct decryption of '100'.
 	share1 := &PartialDecryption{1, b(384111638639)}
 	share2 := &PartialDecryption{2, b(235243761043)}
-	tk := new(ThresholdKey)
+	tk := new(ThresholdPublicKey)
 	tk.Threshold = 2
 	tk.TotalNumberOfDecryptionServers = 2
 	tk.N = b(637753)
@@ -325,7 +325,7 @@ func TestVerifyDecryption(t *testing.T) {
 	tkh := GetThresholdKeyGenerator(10, 2, 2, rand.Reader)
 	tpks, err := tkh.Generate()
 
-	pk := &tpks[0].ThresholdKey
+	pk := &tpks[0].ThresholdPublicKey
 	if err != nil {
 		t.Error(err)
 	}

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -115,12 +115,10 @@ func TestDecryptAndProduceZNP(t *testing.T) {
 	c, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	znp, err := pd.DecryptAndProduceZNP(c.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 
 	if !znp.Verify() {
@@ -174,13 +172,11 @@ func TestEncryptingDecryptingSimple(t *testing.T) {
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	message := b(100)
 	c, err := tpks[1].Encrypt(message, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	share1 := tpks[0].Decrypt(c.C)
 	message2, err := tpks[0].CombinePartialDecryptions([]*PartialDecryption{share1})
@@ -197,13 +193,11 @@ func TestEncryptingDecrypting(t *testing.T) {
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	message := b(100)
 	c, err := tpks[1].Encrypt(message, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	share1 := tpks[0].Decrypt(c.C)
 	share2 := tpks[1].Decrypt(c.C)
@@ -272,23 +266,19 @@ func TestCombinePartialDecryptionsZKP(t *testing.T) {
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	message := b(100)
 	c, err := tpks[1].Encrypt(message, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	share1, err := tpks[0].DecryptAndProduceZNP(c.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	share2, err := tpks[1].DecryptAndProduceZNP(c.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	message2, err := tpks[0].CombinePartialDecryptionsZKP([]*PartialDecryptionZKP{share1, share2})
 	if err != nil {
@@ -338,28 +328,23 @@ func TestVerifyDecryption(t *testing.T) {
 	pk := &tpks[0].ThresholdKey
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	expt := b(101)
 	cypher, err := tpks[0].Encrypt(expt, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	pd1, err := tpks[0].DecryptAndProduceZNP(cypher.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	pd2, err := tpks[1].DecryptAndProduceZNP(cypher.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
-		return
 	}
 	pds := []*PartialDecryptionZKP{pd1, pd2}
 	if err != nil {
 		t.Error(err)
-		return
 	}
 
 	if err = pk.VerifyDecryption(cypher.C, b(101), pds); err != nil {


### PR DESCRIPTION
Here we ship a number of improvements we did when we were evaluating the library to use for our project.

Summary of changes:
- Cleared up single-mode naming as well as removed `G` and `Mu` parameters from Paillier keys. We always use `G = N + 1` (threshold version is not secure with another choice of `G` by the way), `N` is the only one parameter needed for a public key. Also, `Mu` is needed only for decrypting and can be computed from `Lambda` and `N` so there is no need to keep it in the private key.
- Added documentation to `<Key, Enc, Dec>` single-mode functions with an important note that `p` and `q` supplied to `CreatePrivateKey` must be either of equal length or `gcd(pq, (p-1)(q-1)) = 1` which is assured if both primes are of equal length. This requirement is mentioned both in [KL 08] and [DJN 10].
- Removed single-mode `PrivateKey`'s `String()` method and cached `N^2` value from `PublicKey`.
It's better to have no code encouraging to turn key into a string and printing it somewhere, especially that string contained private `Lambda` parameter. Computing `N^2` is just a really small piece of encryption/decryption work and if we decide we need to tweak performance, we will need a different approach anyway. Removing it from `PublicKey` lets to keep this structure clean.
- Removed `G` parameter from `ThresholdKey`. `G` is always equal to `N+1`, only then threshold scheme is safe.
- Added documentation explaining how `ThresholdKey` is generated, how message is encrypted and decrypted, how zero-knowledge proof is constructed.
- Made internal functions not being exported.
- Removed dead code.
- Added test ensuring threshold version is a homomorphic encryption scheme.
- Explained how do we handle negative `Lambda` parameter values when decrypting (modular multiplicative inverse).


[KL 08]: Jonathan Katz, Yehuda Lindell, (2008)
Introduction to Modern Cryptography: Principles and Protocols,
Chapman & Hall/CRC

[DJN 10]: Ivan Damgard, Mads Jurik, Jesper Buus Nielsen, (2010)
A Generalization of Paillier’s Public-Key System with Applications to Electronic Voting
Aarhus University, Dept. of Computer Science, BRICS