### PR TITLE
Improved performance of the safe prime generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 language: go
 go:
-  - 1.3
-  - 1.4
+  - 1.7
   - tip

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// The code is the original Go implementation of rand.Prime optimized for
+// generating safe (Sophie Germain) primes.
+// A safe prime is a prime number of the form 2p + 1, where p is also a prime.
+
 package paillier
 
 import (
@@ -30,11 +34,31 @@ var smallPrimes = []uint8{
 // operations.
 var smallPrimesProduct = new(big.Int).SetUint64(16294579238595022365)
 
-type safePrime struct {
-	p *big.Int
-	q *big.Int
-}
-
+// GenerateSafePrime tries to find a safe prime concurrently.
+// The returned result is a safe prime `p` and prime `q` such that `p=2q+1`.
+// Concurrency level can be controlled with the `concurrencyLevel` parameter.
+// If a safe prime could not be found in the specified `timeout`, the error
+// is returned. Also, if at least one search process failed, error is returned
+// as well.
+//
+// How fast we generate a prime number is mostly a matter of luck and it depends
+// on how lucky we are with drawing the first bytes.
+// With today's multicore processors, we can execute the process on multiple
+// cores concurrently, accept the first valid result and cancel the rest of
+// work. This way, with the same finding algorithm, we can get the result
+// faster.
+//
+// Concurrency level should be set depending on what `bitLen` of prime is
+// expected. For example, as of today, on a typical workstation, for 512-bit
+// safe prime, `concurrencyLevel` should be set to `1` as generating the prime
+// of this length is a matter of milliseconds for a single core.
+// For 1024-bit safe prime, `concurrencyLevel` should be usually set to at least
+// `2` and for 2048-bit safe prime, `concurrencyLevel` must be set to at least
+// `4` to get the result in a reasonable time.
+//
+// This function generates safe primes of at least 6 `bitLen`. For every
+// generated safe prime, the two most significant bits are always set to `1`
+// - we don't want the generated number to be too small.
 func GenerateSafePrime(
 	bitLen int,
 	concurrencyLevel int,
@@ -58,6 +82,7 @@ func GenerateSafePrime(
 		runGenPrimeRoutine(ctx, primeChan, errChan, mutex, rand.Reader, bitLen)
 	}
 
+	// Cancel after the specified timeout.
 	go func() {
 		time.Sleep(timeout)
 		mutex.Lock()
@@ -81,6 +106,46 @@ func GenerateSafePrime(
 	}
 }
 
+type safePrime struct {
+	p *big.Int // p = 2q + 1
+	q *big.Int
+}
+
+// Starts a Goroutine searching for a safe prime of the specified `pBitLen`.
+// If succeeds, writes prime `p` and prime `q` such that `p = 2q+1` to the
+// `primeChan`. Prime `p` has a bit length equal to `pBitLen` and prime `q` has
+// a bit length equal to `pBitLen-1`.
+//
+// The algorithm is as follows:
+// 1. Generate a random odd number `q` of length `pBitLen-1` with two the most
+//    significant bytes set to `1`.
+// 2. Execute preliminary primality test on `q` checking whether it is coprime
+//    to all the elements of `smallPrimes`. It allows to eliminate trivial
+//    cases quickly, when `q` is obviously no prime, without running an
+//    expensive final primality tests.
+//    If `q` is coprime to all of the `smallPrimes`, then go to the point 3.
+//    If not, add `2` and try again. Do it at most 10 times.
+// 3. Check the potentially prime `q`, whether `q = 1 (mod 3)`. This will
+//    happen for 50% of cases.
+//    If it is, then `p = 2q+1` will be a multiple of 3, so it will be obviously
+//    not a prime number. In this case, add `2` and try again. Do it at most 10
+//    times. If `q != 1 (mod 3)`, go to the point 4.
+// 4. Now we know `q` is potentially prime and `p = 2q+1` is not a multiple of
+//    3. We execute a preliminary primality test on `p`, checking whether
+//    it is coprime to all the elements of `smallPrimes` just like we did for
+//    `q` in point 2. If `p` is not coprime to at least one element of the
+//    `smallPrimes`, then go back to point 1.
+//    If `p` is coprime to all the elements of `smallPrimes`, go to point 5.
+// 5. At this point, we know `q` is potentially prime, and `p=q+1` is also
+//    potentially prime. We need to execute a final primality test for `q`.
+//    We apply Miller-Rabin and Baillie-PSW tests. If they succeeds, it means
+//    that `q` is prime with a very high probability. Knowing `q` is prime,
+//    we use Pocklington's criterion to prove the primality of `p=2q+1`, that
+//    is, we execute Fermat primality test to base 2 checking whether
+//    `2^{p-1} = 1 (mod p)`. It's significantly faster than running full
+//    Miller-Rabin and Baillie-PSW for `p`.
+//    If `q` and `p` are found to be prime, return them as a result. If not, go
+//    back to the point 1.
 func runGenPrimeRoutine(
 	ctx context.Context,
 	primeChan chan safePrime,
@@ -113,9 +178,11 @@ func runGenPrimeRoutine(
 					return
 				}
 
-				// Clear bits in the first byte to make sure the candidate has a size <= bits.
+				// Clear bits in the first byte to make sure the candidate has
+				// a size <= bits.
 				bytes[0] &= uint8(int(1<<b) - 1)
-				// Don't let the value be too small, i.e, set the most significant two bits.
+				// Don't let the value be too small, i.e, set the most
+				// significant two bits.
 				// Setting the top two bits, rather than just the top bit,
 				// means that when two of these values are multiplied together,
 				// the result isn't ever one bit short.
@@ -128,7 +195,8 @@ func runGenPrimeRoutine(
 						bytes[1] |= 0x80
 					}
 				}
-				// Make the value odd since an even number this large certainly isn't prime.
+				// Make the value odd since an even number this large certainly
+				// isn't prime.
 				bytes[len(bytes)-1] |= 1
 
 				q.SetBytes(bytes)
@@ -162,6 +230,7 @@ func runGenPrimeRoutine(
 						continue NextDelta
 					}
 
+					// p = 2q+1
 					p.Mul(q, big.NewInt(2))
 					p.Add(p, big.NewInt(1))
 					if !isPrimeCandidate(p) {

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -68,19 +68,19 @@ func GenerateSafePrime(
 		return nil, nil, errors.New("safe prime size must be at least 6 bits")
 	}
 
-	primeChan := make(chan safePrime, 1)
-	errChan := make(chan error, 1)
+	primeChan := make(chan safePrime, concurrencyLevel)
+	errChan := make(chan error, concurrencyLevel)
 
 	defer close(primeChan)
 	defer close(errChan)
 
 	mutex := &sync.Mutex{}
 	waitGroup := &sync.WaitGroup{}
-	waitGroup.Add(concurrencyLevel)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	for i := 0; i < concurrencyLevel; i++ {
+		waitGroup.Add(1)
 		runGenPrimeRoutine(
 			ctx, primeChan, errChan, mutex, waitGroup, random, bitLen,
 		)

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -5,9 +5,14 @@
 package paillier
 
 import (
+	"context"
+	"crypto/rand"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
+	"sync"
+	"time"
 )
 
 // smallPrimes is a list of small, prime numbers that allows us to rapidly
@@ -25,102 +30,165 @@ var smallPrimes = []uint8{
 // operations.
 var smallPrimesProduct = new(big.Int).SetUint64(16294579238595022365)
 
-// Prime returns a number, p, of the given size, such that p is prime
-// with high probability.
-// Prime will return error for any error returned by rand.Read or if bits < 2.
-func SafePrimes(rand io.Reader, bits int) (p *big.Int, q *big.Int, err error) {
-	qbits := bits - 1
+type safePrime struct {
+	p *big.Int
+	q *big.Int
+}
 
-	if qbits < 2 {
-		err = errors.New("crypto/rand: prime size must be at least 2-bit")
-		return
+func GenerateSafePrime(
+	bitLen int,
+	concurrencyLevel int,
+	timeout time.Duration,
+) (*big.Int, *big.Int, error) {
+	if bitLen < 6 {
+		return nil, nil, errors.New("safe prime size must be at least 6 bits")
 	}
 
-	b := uint(qbits % 8)
+	primeChan := make(chan safePrime, 1)
+	errChan := make(chan error, 1)
+
+	defer close(primeChan)
+	defer close(errChan)
+
+	mutex := &sync.Mutex{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	for i := 0; i < concurrencyLevel; i++ {
+		runGenPrimeRoutine(ctx, primeChan, errChan, mutex, rand.Reader, bitLen)
+	}
+
+	go func() {
+		time.Sleep(timeout)
+		mutex.Lock()
+		cancel()
+		mutex.Unlock()
+	}()
+
+	select {
+	case result := <-primeChan:
+		mutex.Lock()
+		cancel()
+		mutex.Unlock()
+		return result.p, result.q, nil
+	case err := <-errChan:
+		mutex.Lock()
+		cancel()
+		mutex.Unlock()
+		return nil, nil, err
+	case <-ctx.Done():
+		return nil, nil, fmt.Errorf("generator timed out after %v", timeout)
+	}
+}
+
+func runGenPrimeRoutine(
+	ctx context.Context,
+	primeChan chan safePrime,
+	errChan chan error,
+	mutex *sync.Mutex,
+	rand io.Reader,
+	pBitLen int,
+) {
+	qBitLen := pBitLen - 1
+	b := uint(qBitLen % 8)
 	if b == 0 {
 		b = 8
 	}
 
-	bytes := make([]byte, (qbits+7)/8)
-	p = new(big.Int)
-	q = new(big.Int)
+	bytes := make([]byte, (qBitLen+7)/8)
+	p := new(big.Int)
+	q := new(big.Int)
 
 	bigMod := new(big.Int)
 
-	//NextRand:
-	for {
-		_, err = io.ReadFull(rand, bytes)
-		if err != nil {
-			return nil, nil, err
-		}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				_, err := io.ReadFull(rand, bytes)
+				if err != nil {
+					errChan <- err
+					return
+				}
 
-		// Clear bits in the first byte to make sure the candidate has a size <= bits.
-		bytes[0] &= uint8(int(1<<b) - 1)
-		// Don't let the value be too small, i.e, set the most significant two bits.
-		// Setting the top two bits, rather than just the top bit,
-		// means that when two of these values are multiplied together,
-		// the result isn't ever one bit short.
-		if b >= 2 {
-			bytes[0] |= 3 << (b - 2)
-		} else {
-			// Here b==1, because b cannot be zero.
-			bytes[0] |= 1
-			if len(bytes) > 1 {
-				bytes[1] |= 0x80
-			}
-		}
-		// Make the value odd since an even number this large certainly isn't prime.
-		bytes[len(bytes)-1] |= 1
+				// Clear bits in the first byte to make sure the candidate has a size <= bits.
+				bytes[0] &= uint8(int(1<<b) - 1)
+				// Don't let the value be too small, i.e, set the most significant two bits.
+				// Setting the top two bits, rather than just the top bit,
+				// means that when two of these values are multiplied together,
+				// the result isn't ever one bit short.
+				if b >= 2 {
+					bytes[0] |= 3 << (b - 2)
+				} else {
+					// Here b==1, because b cannot be zero.
+					bytes[0] |= 1
+					if len(bytes) > 1 {
+						bytes[1] |= 0x80
+					}
+				}
+				// Make the value odd since an even number this large certainly isn't prime.
+				bytes[len(bytes)-1] |= 1
 
-		q.SetBytes(bytes)
+				q.SetBytes(bytes)
 
-		p.Mul(q, big.NewInt(2))
-		p.Add(p, big.NewInt(1))
+				p.Mul(q, big.NewInt(2))
+				p.Add(p, big.NewInt(1))
 
-		// Calculate the value mod the product of smallPrimes. If it's
-		// a multiple of any of these primes we add two until it isn't.
-		// The probability of overflowing is minimal and can be ignored
-		// because we still perform Miller-Rabin tests on the result.
-		bigMod.Mod(q, smallPrimesProduct)
-		mod := bigMod.Uint64()
+				// Calculate the value mod the product of smallPrimes. If it's
+				// a multiple of any of these primes we add two until it isn't.
+				// The probability of overflowing is minimal and can be ignored
+				// because we still perform Miller-Rabin tests on the result.
+				bigMod.Mod(q, smallPrimesProduct)
+				mod := bigMod.Uint64()
 
-	NextDelta:
-		for delta := uint64(0); delta < 1<<20; delta += 2 {
-			m := mod + delta
-			for _, prime := range smallPrimes {
-				if m%uint64(prime) == 0 && (qbits > 6 || m != uint64(prime)) {
-					continue NextDelta
+			NextDelta:
+				for delta := uint64(0); delta < 1<<20; delta += 2 {
+					m := mod + delta
+					for _, prime := range smallPrimes {
+						if m%uint64(prime) == 0 && (qBitLen > 6 || m != uint64(prime)) {
+							continue NextDelta
+						}
+					}
+
+					if delta > 0 {
+						bigMod.SetUint64(delta)
+						q.Add(q, bigMod)
+					}
+
+					qMod3 := new(big.Int).Mod(q, big.NewInt(3))
+					if qMod3.Cmp(big.NewInt(1)) == 0 {
+						continue NextDelta
+					}
+
+					p.Mul(q, big.NewInt(2))
+					p.Add(p, big.NewInt(1))
+					if !isPrimeCandidate(p) {
+						continue NextDelta
+					}
+
+					break
+				}
+
+				// There is a tiny possibility that, by adding delta, we caused
+				// the number to be one bit too long. Thus we check BitLen
+				// here.
+				if q.ProbablyPrime(20) &&
+					isPocklingtonCriterionSatisfied(p) &&
+					q.BitLen() == qBitLen {
+
+					mutex.Lock()
+					if ctx.Err() == nil {
+						primeChan <- safePrime{p, q}
+					}
+					mutex.Unlock()
+
+					return
 				}
 			}
-
-			if delta > 0 {
-				bigMod.SetUint64(delta)
-				q.Add(q, bigMod)
-			}
-
-			qMod3 := new(big.Int).Mod(q, big.NewInt(3))
-			if qMod3.Cmp(big.NewInt(1)) == 0 {
-				continue NextDelta
-			}
-
-			p.Mul(q, big.NewInt(2))
-			p.Add(p, big.NewInt(1))
-			if !isPrimeCandidate(p) {
-				continue NextDelta
-			}
-
-			break
 		}
-
-		// There is a tiny possibility that, by adding delta, we caused
-		// the number to be one bit too long. Thus we check BitLen
-		// here.
-		if q.ProbablyPrime(20) &&
-			isPocklingtonCriterionSatisfied(p) &&
-			q.BitLen() == qbits {
-			return
-		}
-	}
+	}()
 }
 
 func isPocklingtonCriterionSatisfied(p *big.Int) bool {

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -125,7 +125,7 @@ type safePrime struct {
 //
 // The algorithm is as follows:
 // 1. Generate a random odd number `q` of length `pBitLen-1` with two the most
-//    significant bytes set to `1`.
+//    significant bits set to `1`.
 // 2. Execute preliminary primality test on `q` checking whether it is coprime
 //    to all the elements of `smallPrimes`. It allows to eliminate trivial
 //    cases quickly, when `q` is obviously no prime, without running an
@@ -231,6 +231,19 @@ func runGenPrimeRoutine(
 						q.Add(q, bigMod)
 					}
 
+					// If `q = 1 (mod 3)`, then `p` is a multiple of `3` so it's
+					// obviously no prime and such `q` should be rejected.
+					// This will happen in 50% of cases and we should detect
+					// and eliminate them early.
+					//
+					// Explanation:
+					// If q = 1 (mod 3) then there exists a q' such that:
+					// q = 3q' + 1
+					//
+					// Since p = 2q + 1:
+					// p = 2q + 1 = 2(3q' + 1) + 1 = 6q' + 2 + 1 = 6q' + 3 =
+					//   = 3(2q' + 1)
+					// So `p` is a multiple of `3`.
 					qMod3 := new(big.Int).Mod(q, big.NewInt(3))
 					if qMod3.Cmp(big.NewInt(1)) == 0 {
 						continue NextDelta

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -265,6 +265,10 @@ func runGenPrimeRoutine(
 	}()
 }
 
+// Pocklington's criterion can be used to prove the primality of `p = 2q + 1`
+// once one has proven the primality of `q`.
+// With `q` prime, `p = 2q + 1`, and `p` passing Fermat's primality test to base
+// `2` that `2^{p-1} = 1 (mod p)` then `p` is prime as well.
 func isPocklingtonCriterionSatisfied(p *big.Int) bool {
 	return new(big.Int).Exp(
 		big.NewInt(2),

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -210,9 +210,6 @@ func runGenPrimeRoutine(
 
 				q.SetBytes(bytes)
 
-				p.Mul(q, big.NewInt(2))
-				p.Add(p, big.NewInt(1))
-
 				// Calculate the value mod the product of smallPrimes. If it's
 				// a multiple of any of these primes we add two until it isn't.
 				// The probability of overflowing is minimal and can be ignored
@@ -279,9 +276,7 @@ func isPocklingtonCriterionSatisfied(p *big.Int) bool {
 }
 
 func isPrimeCandidate(number *big.Int) bool {
-	bigMod := new(big.Int)
-	bigMod.Mod(number, smallPrimesProduct)
-	m := bigMod.Uint64()
+	m := new(big.Int).Mod(number, smallPrimesProduct).Uint64()
 
 	for _, prime := range smallPrimes {
 		if m%uint64(prime) == 0 && m != uint64(prime) {

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -10,7 +10,6 @@ package paillier
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -63,6 +62,7 @@ func GenerateSafePrime(
 	bitLen int,
 	concurrencyLevel int,
 	timeout time.Duration,
+	random io.Reader,
 ) (p *big.Int, q *big.Int, err error) {
 	if bitLen < 6 {
 		return nil, nil, errors.New("safe prime size must be at least 6 bits")
@@ -82,7 +82,7 @@ func GenerateSafePrime(
 
 	for i := 0; i < concurrencyLevel; i++ {
 		runGenPrimeRoutine(
-			ctx, primeChan, errChan, mutex, waitGroup, rand.Reader, bitLen,
+			ctx, primeChan, errChan, mutex, waitGroup, random, bitLen,
 		)
 	}
 

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -1,0 +1,146 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package paillier
+
+import (
+	"errors"
+	"io"
+	"math/big"
+)
+
+// smallPrimes is a list of small, prime numbers that allows us to rapidly
+// exclude some fraction of composite candidates when searching for a random
+// prime. This list is truncated at the point where smallPrimesProduct exceeds
+// a uint64. It does not include two because we ensure that the candidates are
+// odd by construction.
+var smallPrimes = []uint8{
+	3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+}
+
+// smallPrimesProduct is the product of the values in smallPrimes and allows us
+// to reduce a candidate prime by this number and then determine whether it's
+// coprime to all the elements of smallPrimes without further big.Int
+// operations.
+var smallPrimesProduct = new(big.Int).SetUint64(16294579238595022365)
+
+// Prime returns a number, p, of the given size, such that p is prime
+// with high probability.
+// Prime will return error for any error returned by rand.Read or if bits < 2.
+func SafePrimes(rand io.Reader, bits int) (p *big.Int, q *big.Int, err error) {
+	qbits := bits - 1
+
+	if qbits < 2 {
+		err = errors.New("crypto/rand: prime size must be at least 2-bit")
+		return
+	}
+
+	b := uint(qbits % 8)
+	if b == 0 {
+		b = 8
+	}
+
+	bytes := make([]byte, (qbits+7)/8)
+	p = new(big.Int)
+	q = new(big.Int)
+
+	bigMod := new(big.Int)
+
+	//NextRand:
+	for {
+		_, err = io.ReadFull(rand, bytes)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Clear bits in the first byte to make sure the candidate has a size <= bits.
+		bytes[0] &= uint8(int(1<<b) - 1)
+		// Don't let the value be too small, i.e, set the most significant two bits.
+		// Setting the top two bits, rather than just the top bit,
+		// means that when two of these values are multiplied together,
+		// the result isn't ever one bit short.
+		if b >= 2 {
+			bytes[0] |= 3 << (b - 2)
+		} else {
+			// Here b==1, because b cannot be zero.
+			bytes[0] |= 1
+			if len(bytes) > 1 {
+				bytes[1] |= 0x80
+			}
+		}
+		// Make the value odd since an even number this large certainly isn't prime.
+		bytes[len(bytes)-1] |= 1
+
+		q.SetBytes(bytes)
+
+		p.Mul(q, big.NewInt(2))
+		p.Add(p, big.NewInt(1))
+
+		// Calculate the value mod the product of smallPrimes. If it's
+		// a multiple of any of these primes we add two until it isn't.
+		// The probability of overflowing is minimal and can be ignored
+		// because we still perform Miller-Rabin tests on the result.
+		bigMod.Mod(q, smallPrimesProduct)
+		mod := bigMod.Uint64()
+
+	NextDelta:
+		for delta := uint64(0); delta < 1<<20; delta += 2 {
+			m := mod + delta
+			for _, prime := range smallPrimes {
+				if m%uint64(prime) == 0 && (qbits > 6 || m != uint64(prime)) {
+					continue NextDelta
+				}
+			}
+
+			if delta > 0 {
+				bigMod.SetUint64(delta)
+				q.Add(q, bigMod)
+			}
+
+			qMod3 := new(big.Int).Mod(q, big.NewInt(3))
+			if qMod3.Cmp(big.NewInt(1)) == 0 {
+				continue NextDelta
+			}
+
+			p.Mul(q, big.NewInt(2))
+			p.Add(p, big.NewInt(1))
+			if !isPrimeCandidate(p) {
+				continue NextDelta
+			}
+
+			break
+		}
+
+		// There is a tiny possibility that, by adding delta, we caused
+		// the number to be one bit too long. Thus we check BitLen
+		// here.
+		if q.ProbablyPrime(20) &&
+			isPocklingtonCriterionSatisfied(p) &&
+			q.BitLen() == qbits {
+			return
+		}
+	}
+}
+
+func isPocklingtonCriterionSatisfied(p *big.Int) bool {
+	return new(big.Int).Exp(
+		big.NewInt(2),
+		new(big.Int).Sub(p, big.NewInt(1)),
+		p,
+	).Cmp(big.NewInt(1)) == 0
+}
+
+func isPrimeCandidate(number *big.Int) bool {
+	bigMod := new(big.Int)
+	bigMod.Mod(number, smallPrimesProduct)
+	m := bigMod.Uint64()
+
+	for _, prime := range smallPrimes {
+		if m%uint64(prime) == 0 && m != uint64(prime) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/safe_prime_generator.go
+++ b/safe_prime_generator.go
@@ -145,7 +145,7 @@ type safePrime struct {
 //    If `p` is coprime to all the elements of `smallPrimes`, go to point 5.
 // 5. At this point, we know `q` is potentially prime, and `p=q+1` is also
 //    potentially prime. We need to execute a final primality test for `q`.
-//    We apply Miller-Rabin and Baillie-PSW tests. If they succeeds, it means
+//    We apply Miller-Rabin and Baillie-PSW tests. If they succeed, it means
 //    that `q` is prime with a very high probability. Knowing `q` is prime,
 //    we use Pocklington's criterion to prove the primality of `p=2q+1`, that
 //    is, we execute Fermat primality test to base 2 checking whether

--- a/safe_prime_generator_test.go
+++ b/safe_prime_generator_test.go
@@ -1,0 +1,98 @@
+package paillier
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestAsyncGenerator(t *testing.T) {
+	concurrencyLevel := 4
+
+	var tests = map[string]struct {
+		bitLen        int
+		timeout       time.Duration
+		expectedError error
+	}{
+		"primes successfully generated": {
+			bitLen:        512,
+			timeout:       60 * time.Second,
+			expectedError: nil,
+		},
+		"generator timed out": {
+			bitLen:        8192,
+			timeout:       1 * time.Second,
+			expectedError: errors.New("generator timed out after 1s"),
+		},
+		"bit length is 5": {
+			bitLen:        5,
+			timeout:       1 * time.Second,
+			expectedError: errors.New("safe prime size must be at least 6 bits"),
+		},
+		"bit length is 6": {
+			bitLen:        6,
+			timeout:       60 * time.Second,
+			expectedError: nil,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			p, q, err := GenerateSafePrime(
+				test.bitLen,
+				concurrencyLevel,
+				test.timeout,
+			)
+
+			if test.expectedError != nil {
+				if !reflect.DeepEqual(test.expectedError, err) {
+					t.Fatalf(
+						"Unexpected error\nActual: %v\nExpected: %v",
+						err,
+						test.expectedError,
+					)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !p.ProbablyPrime(20) {
+					t.Errorf("p is not prime; p = %v", p)
+				}
+
+				if !q.ProbablyPrime(20) {
+					t.Errorf("q is not prime; q = %v", q)
+				}
+
+				// p = 2q + 1 ?
+				expectedP := new(big.Int)
+				expectedP.Mul(big.NewInt(2), q)
+				expectedP.Add(expectedP, big.NewInt(1))
+
+				if expectedP.Cmp(p) != 0 {
+					t.Errorf("2q + 1 != p")
+				}
+
+				if len(p.Bytes()) != test.bitLen {
+					fmt.Errorf(
+						"Unexpected p bit length\nActual: %v\nExpected: %v",
+						len(p.Bytes()),
+						test.bitLen,
+					)
+				}
+
+				if len(q.Bytes()) != test.bitLen-1 {
+					fmt.Errorf(
+						"Unexpected q bit length\nActual: %v\nExpected: %v",
+						len(q.Bytes()),
+						test.bitLen-1,
+					)
+				}
+			}
+		})
+	}
+}

--- a/safe_prime_generator_test.go
+++ b/safe_prime_generator_test.go
@@ -1,8 +1,8 @@
 package paillier
 
 import (
+	"crypto/rand"
 	"errors"
-	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -44,6 +44,7 @@ func TestAsyncGenerator(t *testing.T) {
 				test.bitLen,
 				concurrencyLevel,
 				test.timeout,
+				rand.Reader,
 			)
 
 			if test.expectedError != nil {
@@ -59,38 +60,7 @@ func TestAsyncGenerator(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				if !p.ProbablyPrime(20) {
-					t.Errorf("p is not prime; p = %v", p)
-				}
-
-				if !q.ProbablyPrime(20) {
-					t.Errorf("q is not prime; q = %v", q)
-				}
-
-				// p = 2q + 1 ?
-				expectedP := new(big.Int)
-				expectedP.Mul(big.NewInt(2), q)
-				expectedP.Add(expectedP, big.NewInt(1))
-
-				if expectedP.Cmp(p) != 0 {
-					t.Errorf("2q + 1 != p")
-				}
-
-				if p.BitLen() != test.bitLen {
-					t.Fatalf(
-						"Unexpected p bit length\nActual: %v\nExpected: %v",
-						p.BitLen(),
-						test.bitLen,
-					)
-				}
-
-				if q.BitLen() != test.bitLen-1 {
-					t.Fatalf(
-						"Unexpected q bit length\nActual: %v\nExpected: %v",
-						q.BitLen(),
-						test.bitLen-1,
-					)
-				}
+				AreSafePrimes(p, q, test.bitLen, t)
 			}
 		})
 	}

--- a/safe_prime_generator_test.go
+++ b/safe_prime_generator_test.go
@@ -2,7 +2,6 @@ package paillier
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -77,18 +76,18 @@ func TestAsyncGenerator(t *testing.T) {
 					t.Errorf("2q + 1 != p")
 				}
 
-				if len(p.Bytes()) != test.bitLen {
-					fmt.Errorf(
+				if p.BitLen() != test.bitLen {
+					t.Fatalf(
 						"Unexpected p bit length\nActual: %v\nExpected: %v",
-						len(p.Bytes()),
+						p.BitLen(),
 						test.bitLen,
 					)
 				}
 
-				if len(q.Bytes()) != test.bitLen-1 {
-					fmt.Errorf(
+				if q.BitLen() != test.bitLen-1 {
+					t.Fatalf(
 						"Unexpected q bit length\nActual: %v\nExpected: %v",
-						len(q.Bytes()),
+						q.BitLen(),
 						test.bitLen-1,
 					)
 				}

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -59,7 +59,9 @@ func GetThresholdKeyGenerator(nbits, TotalNumberOfDecryptionServers, Threshold i
 }
 
 func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, error) {
-	return GenerateSafePrime(tkg.nbits, 4, 120*time.Second, tkg.Random)
+	concurrencyLevel := 4
+	timeout := 120 * time.Second
+	return GenerateSafePrime(tkg.nbits, concurrencyLevel, timeout, tkg.Random)
 }
 
 func (tkg *ThresholdKeyGenerator) initPandP1() error {

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"io"
 	"math/big"
+	"time"
 )
 
 // Generates a threshold Paillier key with an algorithm based on [DJN 10],
@@ -58,7 +59,7 @@ func GetThresholdKeyGenerator(nbits, TotalNumberOfDecryptionServers, Threshold i
 }
 
 func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, error) {
-	return GenerateSafePrimes(tkg.nbits, tkg.Random)
+	return GenerateSafePrime(tkg.nbits, 4, 120*time.Second, tkg.Random)
 }
 
 func (tkg *ThresholdKeyGenerator) initPandP1() error {

--- a/utils.go
+++ b/utils.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"io"
 	"math/big"
-	"time"
 )
 
 var ZERO = big.NewInt(0)
@@ -19,15 +18,6 @@ func Factorial(n int) *big.Int {
 		ret = new(big.Int).Mul(ret, big.NewInt(int64(i)))
 	}
 	return ret
-}
-
-//  Returns 2 primes such that p = 2 * q + 1 and that the length of
-//  p is nbits.  `p` is called a safe prime
-//
-// Deprecated: This function has been left here just for backward compatibility.
-// Please use `GenerateSafePrime` from the `safe_prime_generator.go` directly.
-func GenerateSafePrimes(nbits int, random io.Reader) (p, q *big.Int, err error) {
-	return GenerateSafePrime(nbits, 4, 120*time.Second)
 }
 
 // Generate a random element in the group of all the elements in Z/nZ that

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"io"
 	"math/big"
+	"time"
 )
 
 var ZERO = big.NewInt(0)
@@ -22,18 +23,11 @@ func Factorial(n int) *big.Int {
 
 //  Returns 2 primes such that p = 2 * q + 1 and that the length of
 //  p is nbits.  `p` is called a safe prime
+//
+// Deprecated: This function has been left here just for backward compatibility.
+// Please use `GenerateSafePrime` from the `safe_prime_generator.go` directly.
 func GenerateSafePrimes(nbits int, random io.Reader) (p, q *big.Int, err error) {
-	for {
-		q, err = rand.Prime(random, nbits-1)
-		if err != nil {
-			return
-		}
-		p = (new(big.Int)).Mul(q, big.NewInt(2))
-		p = p.Add(p, big.NewInt(1))
-		if p.ProbablyPrime(50) { //a probability of 2**-100 of not being prime
-			return
-		}
-	}
+	return GenerateSafePrime(nbits, 4, 120*time.Second)
 }
 
 // Generate a random element in the group of all the elements in Z/nZ that

--- a/utils_test.go
+++ b/utils_test.go
@@ -87,16 +87,6 @@ func GetEntireRQn(n int) map[int]bool {
 	return ret
 }
 
-func TestGenerateSafePrimes(t *testing.T) {
-	for i := 0; i < 10; i++ {
-		p, q, err := GenerateSafePrimes(20, rand.Reader)
-		if err != nil {
-			t.Error(err)
-		}
-		AreSafePrimes(p, q, 20, t)
-	}
-}
-
 func TestGetRandomGeneratorOfTheQuadraticResidue(t *testing.T) {
 	tooSmallPrime1, tooSmallPrime2 := b(347), b(359)
 	m := new(big.Int).Mul(tooSmallPrime1, tooSmallPrime2)


### PR DESCRIPTION
This PR aims at improving performance of the safe prime generator. The previous approach was as follows:
```
1. Generate prime `q` of `nBits - 1`
2. Compute `p = 2q + 1`.
3. Check if `p` is prime. If it is, return `(p,q)`. If not, go back to the point 1.
```

This approach was simple, but not fast enough. In this PR, we propose an alternative algorithm as well as make the search process concurrent.

The new algorithm is as follows:
```
1. Generate a random odd number `q` of length `pBitLen-1` with two the most
   significant bytes set to `1`.
2. Execute preliminary primality test on `q` checking whether it is coprime
   to all the elements of `smallPrimes`. It allows to eliminate trivial
   cases quickly, when `q` is obviously no prime, without running an
   expensive final primality tests.
   If `q` is coprime to all of the `smallPrimes`, then go to the point 3.
   If not, add `2` and try again. Do it at most 10 times.
3. Check the potentially prime `q`, whether `q = 1 (mod 3)`. This will
   happen for 50% of cases.
   If it is, then `p = 2q+1` will be a multiple of 3, so it will be obviously
   not a prime number. In this case, add `2` and try again. Do it at most 10
   times. If `q != 1 (mod 3)`, go to the point 4.
4. Now we know `q` is potentially prime and `p = 2q+1` is not a multiple of
   3. We execute a preliminary primality test on `p`, checking whether
   it is coprime to all the elements of `smallPrimes` just like we did for
   `q` in point 2. If `p` is not coprime to at least one element of the
   `smallPrimes`, then go back to point 1.
   If `p` is coprime to all the elements of `smallPrimes`, go to point 5.
5. At this point, we know `q` is potentially prime, and `p=q+1` is also
   potentially prime. We need to execute a final primality test for `q`.
   We apply Miller-Rabin and Baillie-PSW tests. If they succeed, it means
   that `q` is prime with a very high probability. Knowing `q` is prime,
   we use Pocklington's criterion to prove the primality of `p=2q+1`, that
   is, we execute Fermat primality test to base 2 checking whether
   `2^{p-1} = 1 (mod p)`. It's significantly faster than running full
   Miller-Rabin and Baillie-PSW for `p`.
   If `q` and `p` are found to be prime, return them as a result. If not, go
   back to the point 1.
```

How fast we generate a prime number is mostly a matter of luck and it depends on how lucky we are with choosing the first bytes. With today's multicore processors, we can execute the process on multiple cores concurrently, accept the first valid result and cancel the rest of work. This way, with the same finding algorithm, we can get the result faster. Such an approach is presented in this PR.

Detailed benchmark results are presented in the comment. We can observe an improvement in almost all cases (still, a small factor of luck is needed). I've tested for `512`, `1024` and `2048` bit numbers on my MBP 3,1 GHz Intel Core i7 with concurrency level set to 4. 
I did not present a result for `2048` bits, since the previous algorithm wasn't able to produce one `2048`bit safe prime in one hour so I had nothing to compare.

If you want, you can compare the new approach with the performance of `openssl dhparam -5 2048`. (512/1024). 

The original PR with a discussion/review on our side: https://github.com/keep-network/paillier/pull/8