### PR TITLE
Plaintext space check

### DIFF
--- a/paillier.go
+++ b/paillier.go
@@ -15,8 +15,8 @@ func (pk *PublicKey) GetNSquare() *big.Int {
 }
 
 // EncryptWithR encrypts a plaintext into a cypher one with random `r` specified
-// in the argument. The plain text must be smaller that N and bigger or equal
-// than zero. `r` is the randomness used to encrypt the plaintext. `r` must be
+// in the argument. The plain text must be smaller that N and bigger than or
+// equal zero. `r` is the randomness used to encrypt the plaintext. `r` must be
 // a random element from a multiplicative group of integers modulo N.
 //
 // If you don't need to use the specific `r`, you should use the `Encrypt`
@@ -28,6 +28,14 @@ func (pk *PublicKey) GetNSquare() *big.Int {
 //
 // See [KL 08] construction 11.32, page 414.
 func (pk *PublicKey) EncryptWithR(m *big.Int, r *big.Int) (*Cypher, error) {
+	if m.Cmp(ZERO) == -1 || m.Cmp(pk.N) != -1 { // m < 0 || m >= N  ?
+		return nil, fmt.Errorf(
+			"%v is out of allowed plaintext space [0, %v)",
+			m,
+			pk.N,
+		)
+	}
+
 	nSquare := pk.GetNSquare()
 
 	// g is _always_ equal n+1
@@ -40,7 +48,7 @@ func (pk *PublicKey) EncryptWithR(m *big.Int, r *big.Int) (*Cypher, error) {
 }
 
 // Encrypt a plaintext into a cypher one. The plain text must be smaller that
-// N and bigger or equal than zero. random is usually rand.Reader from the
+// N and bigger than or equal zero. random is usually rand.Reader from the
 // package crypto/rand.
 //
 // m - plaintext to encrypt

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -2,7 +2,9 @@ package paillier
 
 import (
 	"crypto/rand"
+	"errors"
 	"math/big"
+	"reflect"
 	"testing"
 )
 
@@ -60,6 +62,65 @@ func TestEncryptDecryptSmall(t *testing.T) {
 		if initialValue.Cmp(returnedValue) != 0 {
 			t.Error("wrong decryption ", returnedValue, " is not ", initialValue)
 		}
+	}
+}
+
+func TestCheckPlaintextSpace(t *testing.T) {
+	p := big.NewInt(13)
+	q := big.NewInt(11)
+
+	// N = pq = 143 so the plaintext space is [0, 143)
+	privateKey := CreatePrivateKey(p, q)
+
+	var tests = map[string]struct {
+		plaintext     *big.Int
+		expectedError error
+	}{
+		"plaintext less than 0": {
+			plaintext:     big.NewInt(-1),
+			expectedError: errors.New("-1 is out of allowed plaintext space [0, 143)"),
+		},
+		"plaintext equal 0": {
+			plaintext: big.NewInt(0),
+		},
+		"plaintext equal 1": {
+			plaintext: big.NewInt(1),
+		},
+		"plaintext equal 142": {
+			plaintext: big.NewInt(142),
+		},
+		"plaintext equal 143": {
+			plaintext:     big.NewInt(143),
+			expectedError: errors.New("143 is out of allowed plaintext space [0, 143)"),
+		},
+		"plaintext equal 144": {
+			plaintext:     big.NewInt(144),
+			expectedError: errors.New("144 is out of allowed plaintext space [0, 143)"),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cypher, err := privateKey.Encrypt(test.plaintext, rand.Reader)
+			if !reflect.DeepEqual(err, test.expectedError) {
+				t.Errorf(
+					"Unexpected error\nExpected: %v\nActual: %v",
+					test.expectedError,
+					err,
+				)
+			}
+
+			if test.expectedError == nil {
+				decrypted := privateKey.Decrypt(cypher)
+				if test.plaintext.Cmp(decrypted) != 0 {
+					t.Errorf(
+						"Unexpected decryption\nExpected: %v\nActual: %v",
+						test.plaintext,
+						decrypted,
+					)
+				}
+			}
+		})
 	}
 }
 

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -142,13 +142,13 @@ func TestAddCyphers(t *testing.T) {
 func TestAddCypherWithSmallKeyModulus(t *testing.T) {
 	privateKey := CreatePrivateKey(big.NewInt(7), big.NewInt(5))
 
-	cypher1, _ := privateKey.Encrypt(big.NewInt(41), rand.Reader)
-	cypher2, _ := privateKey.Encrypt(big.NewInt(219), rand.Reader)
-	cypher3, _ := privateKey.Encrypt(big.NewInt(54), rand.Reader)
+	cypher1, _ := privateKey.Encrypt(big.NewInt(30), rand.Reader)
+	cypher2, _ := privateKey.Encrypt(big.NewInt(25), rand.Reader)
+	cypher3, _ := privateKey.Encrypt(big.NewInt(11), rand.Reader)
 	cypher4 := privateKey.Add(cypher1, cypher2, cypher3)
 
 	m := privateKey.Decrypt(cypher4)
-	if m.Cmp(big.NewInt(34)) != 0 {
+	if m.Cmp(big.NewInt(31)) != 0 {
 		t.Errorf("Unexpected decrypted value [%v]", m)
 	}
 }


### PR DESCRIPTION
According to [DJN 10], the plaintext space is `Z_n`. We had this information in the `Encrypt` and `EncryptWithR` documentation but sometimes, when encrypting result of more complex equations, it's easy to miss the fact their result is out of the allowed range.

Here we have just a safety check making sure that if plaintext is out of the allowed space, we report an error.

To better illustrate why it does not make sense to allow encrypting values out of `Z_n`, let's use a simple example for `n = 143`:
```
m = -141 -> D(E(m)) = 0
m = -142 -> D(E(m)) = 0
m = -143,  -> D(E(m)) = 0
m = -144 -> D(E(m)) = 0
m = -145 -> D(E(m)) = 0
```
we can't restore the original value of `m`.

Now for positive integers:
```
m = 141 -> D(E(m)) = 141
m = 142 -> D(E(m)) = 142
m = 143 -> D(E(m)) = 0
m = 144 -> D(E(m)) = 1
m  = 145 -> D(E(m)) = 2
```
We can restore the original message for `m < n (143)` but for `m > 143` we can't really go back to the original value. If we allow for any positive `m`, `D(E(m)) = 1` means that `m` is either `1` or it's `m = nk + 1` for any positive `k`. Since we can't restore the original message unambiguously, allowing for `m >=n` does not make sense.

[DJN 10]: Ivan Damgard, Mads Jurik, Jesper Buus Nielsen, (2010)
               A Generalization of Paillier’s Public-Key System
               with Applications to Electronic Voting
               Aarhus University, Dept. of Computer Science, BRICS