### PR TITLE
Fix spelling/naming issues, slightly more robust testing of encryption and decryption. 

### DIFF
--- a/bson/encoding_cypher.go
+++ b/bson/encoding_cypher.go
@@ -9,15 +9,15 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-type SerializableCypher paillier.Cypher
+type SerializableCypher paillier.Ciphertext
 
-// Serializes Cypher to BSON
-func SerializeCypher(cypher *paillier.Cypher) ([]byte, error) {
-	return bson.Marshal(toSerializableCypher(cypher))
+// Serializes Ciphertext to BSON
+func SerializeCypher(ct *paillier.Ciphertext) ([]byte, error) {
+	return bson.Marshal(toSerializableCypher(ct))
 }
 
-// Deserializes BSON to Cypher
-func DeserializeCypher(data []byte) (*paillier.Cypher, error) {
+// Deserializes BSON to Ciphertext
+func DeserializeCypher(data []byte) (*paillier.Ciphertext, error) {
 	serializable := new(SerializableCypher)
 	if err := bson.Unmarshal(data, serializable); err != nil {
 		return nil, err
@@ -26,13 +26,13 @@ func DeserializeCypher(data []byte) (*paillier.Cypher, error) {
 	return toOriginalCypher(serializable), nil
 }
 
-func toSerializableCypher(cypher *paillier.Cypher) *SerializableCypher {
-	serializable := SerializableCypher(*cypher)
+func toSerializableCypher(ct *paillier.Ciphertext) *SerializableCypher {
+	serializable := SerializableCypher(*ct)
 	return &serializable
 }
 
-func toOriginalCypher(serializable *SerializableCypher) *paillier.Cypher {
-	original := paillier.Cypher(*serializable)
+func toOriginalCypher(serializable *SerializableCypher) *paillier.Ciphertext {
+	original := paillier.Ciphertext(*serializable)
 	return &original
 }
 
@@ -40,17 +40,17 @@ type dbCypher struct {
 	C string
 }
 
-func (cypher *SerializableCypher) GetBSON() (interface{}, error) {
-	return &dbCypher{fmt.Sprintf("%x", cypher.C)}, nil
+func (ct *SerializableCypher) GetBSON() (interface{}, error) {
+	return &dbCypher{fmt.Sprintf("%x", ct.C)}, nil
 }
 
-func (cypher *SerializableCypher) SetBSON(raw bson.Raw) error {
+func (ct *SerializableCypher) SetBSON(raw bson.Raw) error {
 	c := dbCypher{}
 	if err := raw.Unmarshal(&c); err != nil {
 		return err
 	}
 	var ok bool
-	cypher.C, ok = new(big.Int).SetString(c.C, 16)
+	ct.C, ok = new(big.Int).SetString(c.C, 16)
 	if !ok {
 		return errors.New("big int not in hexadecimal format")
 	}

--- a/bson/encoding_cypher_test.go
+++ b/bson/encoding_cypher_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestCypherBsonSerialization(t *testing.T) {
-	cypher := &paillier.Cypher{
+	ct := &paillier.Ciphertext{
 		C: b(5),
 	}
 
-	serialized, err := SerializeCypher(cypher)
+	serialized, err := SerializeCypher(ct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,11 +22,11 @@ func TestCypherBsonSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(cypher, deserialized) {
+	if !reflect.DeepEqual(ct, deserialized) {
 		t.Errorf(
 			"Unexpected serialization result\nActual: %v\nExpected: %v\n",
 			deserialized,
-			cypher,
+			ct,
 		)
 	}
 }

--- a/bson/encoding_privatekey.go
+++ b/bson/encoding_privatekey.go
@@ -7,65 +7,65 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-type SerializablePrivateKey paillier.PrivateKey
+type SerializableSecretKey paillier.SecretKey
 
-// Serializes PrivateKey to BSON
-func SerializePrivateKey(key *paillier.PrivateKey) ([]byte, error) {
-	return bson.Marshal(toSerializablePrivateKey(key))
+// Serializes SecretKey to BSON
+func SerializeSecretKey(key *paillier.SecretKey) ([]byte, error) {
+	return bson.Marshal(toSerializableSecretKey(key))
 }
 
-// Deserializes BSON to PrivateKey
-func DeserializePrivateKey(data []byte) (*paillier.PrivateKey, error) {
-	serializable := new(SerializablePrivateKey)
+// Deserializes BSON to SecretKey
+func DeserializeSecretKey(data []byte) (*paillier.SecretKey, error) {
+	serializable := new(SerializableSecretKey)
 	if err := bson.Unmarshal(data, serializable); err != nil {
 		return nil, err
 	}
 
-	return toOriginalPrivateKey(serializable), nil
+	return toOriginalSecretKey(serializable), nil
 }
 
-func toSerializablePrivateKey(key *paillier.PrivateKey) *SerializablePrivateKey {
-	serializable := SerializablePrivateKey(*key)
+func toSerializableSecretKey(key *paillier.SecretKey) *SerializableSecretKey {
+	serializable := SerializableSecretKey(*key)
 	return &serializable
 }
 
-func toOriginalPrivateKey(serializable *SerializablePrivateKey) *paillier.PrivateKey {
-	original := paillier.PrivateKey(*serializable)
+func toOriginalSecretKey(serializable *SerializableSecretKey) *paillier.SecretKey {
+	original := paillier.SecretKey(*serializable)
 	return &original
 }
 
-type dbPrivateKey struct {
+type dbSecretKey struct {
 	N      string `bson:",omitempty"`
 	Lambda string `bson:",omitempty"`
 	Mu     string `bson:",omitempty"`
 }
 
-func (privateKey *SerializablePrivateKey) GetBSON() (interface{}, error) {
+func (SecretKey *SerializableSecretKey) GetBSON() (interface{}, error) {
 	m := make(map[string]string)
 
-	if privateKey.N != nil {
-		m["n"] = fmt.Sprintf("%x", privateKey.N)
+	if SecretKey.N != nil {
+		m["n"] = fmt.Sprintf("%x", SecretKey.N)
 	}
-	if privateKey.Lambda != nil {
-		m["lambda"] = fmt.Sprintf("%x", privateKey.Lambda)
+	if SecretKey.Lambda != nil {
+		m["lambda"] = fmt.Sprintf("%x", SecretKey.Lambda)
 	}
 	return m, nil
 }
 
-func (privateKey *SerializablePrivateKey) SetBSON(raw bson.Raw) error {
+func (SecretKey *SerializableSecretKey) SetBSON(raw bson.Raw) error {
 	var err error = nil
-	c := new(dbPrivateKey)
+	c := new(dbSecretKey)
 	raw.Unmarshal(c)
 
 	if c.N != "" {
-		privateKey.N, err = fromHex(c.N)
+		SecretKey.N, err = fromHex(c.N)
 		if err != nil {
 			return err
 		}
 	}
 
 	if c.Lambda != "" {
-		privateKey.Lambda, err = fromHex(c.Lambda)
+		SecretKey.Lambda, err = fromHex(c.Lambda)
 		if err != nil {
 			return err
 		}

--- a/bson/encoding_privatekey_test.go
+++ b/bson/encoding_privatekey_test.go
@@ -7,20 +7,20 @@ import (
 	"github.com/keep-network/paillier"
 )
 
-func TestPrivateKeyBsonSerialization(t *testing.T) {
-	key := &paillier.PrivateKey{
+func TestSecretKeyBsonSerialization(t *testing.T) {
+	key := &paillier.SecretKey{
 		PublicKey: paillier.PublicKey{
 			N: (b(345)),
 		},
 		Lambda: b(5),
 	}
 
-	serialized, err := SerializePrivateKey(key)
+	serialized, err := SerializeSecretKey(key)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	deserialized, err := DeserializePrivateKey(serialized)
+	deserialized, err := DeserializeSecretKey(serialized)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/paillier.go
+++ b/paillier.go
@@ -102,7 +102,7 @@ func (pk *PublicKey) Mul(cypher *Cypher, scalar *big.Int) *Cypher {
 	}
 }
 
-type PrivateKey struct {
+type SecretKey struct {
 	PublicKey
 	Lambda *big.Int
 }
@@ -115,7 +115,7 @@ type PrivateKey struct {
 // D(c) = [ ((c^lambda) mod N^2) - 1) / N ] lambda^-1 mod N
 //
 // See [KL 08] construction 11.32, page 414.
-func (priv *PrivateKey) Decrypt(cypher *Cypher) (msg *big.Int) {
+func (priv *SecretKey) Decrypt(cypher *Cypher) (msg *big.Int) {
 	mu := new(big.Int).ModInverse(priv.Lambda, priv.N)
 	tmp := new(big.Int).Exp(cypher.C, priv.Lambda, priv.GetNSquare())
 	msg = new(big.Int).Mod(new(big.Int).Mul(L(tmp, priv.N), mu), priv.N)
@@ -143,7 +143,7 @@ func computePhi(p, q *big.Int) *big.Int {
 	return new(big.Int).Mul(minusOne(p), minusOne(q))
 }
 
-// CreatePrivateKey generates a Paillier private key accepting two large prime
+// CreateSecretKey generates a Paillier private key accepting two large prime
 // numbers of equal length or other such that gcd(pq, (p-1)(q-1)) = 1.
 //
 // Algorithm is based on approach described in [KL 08], construction 11.32,
@@ -159,11 +159,11 @@ func computePhi(p, q *big.Int) *big.Int {
 //               A Generalization of Paillier’s Public-Key System
 //               with Applications to Electronic Voting
 //               Aarhus University, Dept. of Computer Science, BRICS
-func CreatePrivateKey(p, q *big.Int) *PrivateKey {
+func CreateSecretKey(p, q *big.Int) *SecretKey {
 	n := new(big.Int).Mul(p, q)
 	lambda := computePhi(p, q)
 
-	return &PrivateKey{
+	return &SecretKey{
 		PublicKey: PublicKey{
 			N: n,
 		},

--- a/paillier.go
+++ b/paillier.go
@@ -115,10 +115,10 @@ type SecretKey struct {
 // D(c) = [ ((c^lambda) mod N^2) - 1) / N ] lambda^-1 mod N
 //
 // See [KL 08] construction 11.32, page 414.
-func (priv *SecretKey) Decrypt(cypher *Cypher) (msg *big.Int) {
-	mu := new(big.Int).ModInverse(priv.Lambda, priv.N)
-	tmp := new(big.Int).Exp(cypher.C, priv.Lambda, priv.GetNSquare())
-	msg = new(big.Int).Mod(new(big.Int).Mul(L(tmp, priv.N), mu), priv.N)
+func (sk *SecretKey) Decrypt(cypher *Cypher) (msg *big.Int) {
+	mu := new(big.Int).ModInverse(sk.Lambda, sk.N)
+	tmp := new(big.Int).Exp(cypher.C, sk.Lambda, sk.GetNSquare())
+	msg = new(big.Int).Mod(new(big.Int).Mul(L(tmp, sk.N), mu), sk.N)
 	return
 }
 
@@ -143,12 +143,12 @@ func computePhi(p, q *big.Int) *big.Int {
 	return new(big.Int).Mul(minusOne(p), minusOne(q))
 }
 
-// CreateSecretKey generates a Paillier private key accepting two large prime
+// CreateSecretKey generates a Paillier skate key accepting two large prime
 // numbers of equal length or other such that gcd(pq, (p-1)(q-1)) = 1.
 //
 // Algorithm is based on approach described in [KL 08], construction 11.32,
 // page 414 which is compatible with one described in [DJN 10], section 3.2
-// except that instead of generating Lambda private key component from LCM
+// except that instead of generating Lambda skate key component from LCM
 // of p and q we use Euler's totient function as suggested in [KL 08].
 //
 //     [KL 08]:  Jonathan Katz, Yehuda Lindell, (2008)

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -54,11 +54,11 @@ func TestEncryptDecryptSmall(t *testing.T) {
 		SecretKey := CreateSecretKey(p, q)
 
 		initialValue := big.NewInt(100)
-		cypher, err := SecretKey.Encrypt(initialValue, rand.Reader)
+		ct, err := SecretKey.Encrypt(initialValue, rand.Reader)
 		if err != nil {
 			t.Error(err)
 		}
-		returnedValue := SecretKey.Decrypt(cypher)
+		returnedValue := SecretKey.Decrypt(ct)
 		if initialValue.Cmp(returnedValue) != 0 {
 			t.Error("wrong decryption ", returnedValue, " is not ", initialValue)
 		}
@@ -101,7 +101,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			cypher, err := SecretKey.Encrypt(test.plaintext, rand.Reader)
+			ct, err := SecretKey.Encrypt(test.plaintext, rand.Reader)
 			if !reflect.DeepEqual(err, test.expectedError) {
 				t.Errorf(
 					"Unexpected error\nExpected: %v\nActual: %v",
@@ -111,7 +111,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 			}
 
 			if test.expectedError == nil {
-				decrypted := SecretKey.Decrypt(cypher)
+				decrypted := SecretKey.Decrypt(ct)
 				if test.plaintext.Cmp(decrypted) != 0 {
 					t.Errorf(
 						"Unexpected decryption\nExpected: %v\nActual: %v",
@@ -156,12 +156,12 @@ func TestAddCypherWithSmallKeyModulus(t *testing.T) {
 func TestMulCypher(t *testing.T) {
 	SecretKey := CreateSecretKey(big.NewInt(17), big.NewInt(13))
 
-	cypher, err := SecretKey.Encrypt(big.NewInt(3), rand.Reader)
+	ct, err := SecretKey.Encrypt(big.NewInt(3), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cypherMultiple := SecretKey.Mul(cypher, big.NewInt(7))
+	cypherMultiple := SecretKey.Mul(ct, big.NewInt(7))
 	multiple := SecretKey.Decrypt(cypherMultiple)
 
 	// 3 * 7 = 21
@@ -173,12 +173,12 @@ func TestMulCypher(t *testing.T) {
 func TestMulCypherWithSmallKeyModulus(t *testing.T) {
 	SecretKey := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
-	cypher, err := SecretKey.Encrypt(big.NewInt(30), rand.Reader)
+	ct, err := SecretKey.Encrypt(big.NewInt(30), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cypherMultiple := SecretKey.Mul(cypher, big.NewInt(93))
+	cypherMultiple := SecretKey.Mul(ct, big.NewInt(93))
 	multiple := SecretKey.Decrypt(cypherMultiple)
 
 	// (30*93) mod (7*5) = 25

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -32,18 +32,18 @@ func TestComputePhi(t *testing.T) {
 	}
 }
 
-func TestCreatePrivateKey(t *testing.T) {
+func TestCreateSecretKey(t *testing.T) {
 	p := big.NewInt(463)
 	q := big.NewInt(631)
 
-	privateKey := CreatePrivateKey(p, q)
+	SecretKey := CreateSecretKey(p, q)
 
-	if privateKey.N.Cmp(big.NewInt(292153)) != 0 {
-		t.Errorf("Unexpected N PublicKey value [%v]", privateKey.N)
+	if SecretKey.N.Cmp(big.NewInt(292153)) != 0 {
+		t.Errorf("Unexpected N PublicKey value [%v]", SecretKey.N)
 	}
 
-	if privateKey.Lambda.Cmp(big.NewInt(291060)) != 0 {
-		t.Errorf("Unexpected Lambda Public key value [%v]", privateKey.Lambda)
+	if SecretKey.Lambda.Cmp(big.NewInt(291060)) != 0 {
+		t.Errorf("Unexpected Lambda Public key value [%v]", SecretKey.Lambda)
 	}
 }
 
@@ -51,14 +51,14 @@ func TestEncryptDecryptSmall(t *testing.T) {
 	p := big.NewInt(13)
 	q := big.NewInt(11)
 	for i := 1; i < 10; i++ {
-		privateKey := CreatePrivateKey(p, q)
+		SecretKey := CreateSecretKey(p, q)
 
 		initialValue := big.NewInt(100)
-		cypher, err := privateKey.Encrypt(initialValue, rand.Reader)
+		cypher, err := SecretKey.Encrypt(initialValue, rand.Reader)
 		if err != nil {
 			t.Error(err)
 		}
-		returnedValue := privateKey.Decrypt(cypher)
+		returnedValue := SecretKey.Decrypt(cypher)
 		if initialValue.Cmp(returnedValue) != 0 {
 			t.Error("wrong decryption ", returnedValue, " is not ", initialValue)
 		}
@@ -70,7 +70,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 	q := big.NewInt(11)
 
 	// N = pq = 143 so the plaintext space is [0, 143)
-	privateKey := CreatePrivateKey(p, q)
+	SecretKey := CreateSecretKey(p, q)
 
 	var tests = map[string]struct {
 		plaintext     *big.Int
@@ -101,7 +101,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			cypher, err := privateKey.Encrypt(test.plaintext, rand.Reader)
+			cypher, err := SecretKey.Encrypt(test.plaintext, rand.Reader)
 			if !reflect.DeepEqual(err, test.expectedError) {
 				t.Errorf(
 					"Unexpected error\nExpected: %v\nActual: %v",
@@ -111,7 +111,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 			}
 
 			if test.expectedError == nil {
-				decrypted := privateKey.Decrypt(cypher)
+				decrypted := SecretKey.Decrypt(cypher)
 				if test.plaintext.Cmp(decrypted) != 0 {
 					t.Errorf(
 						"Unexpected decryption\nExpected: %v\nActual: %v",
@@ -125,44 +125,44 @@ func TestCheckPlaintextSpace(t *testing.T) {
 }
 
 func TestAddCyphers(t *testing.T) {
-	privateKey := CreatePrivateKey(big.NewInt(17), big.NewInt(13))
+	SecretKey := CreateSecretKey(big.NewInt(17), big.NewInt(13))
 
-	cypher1, _ := privateKey.Encrypt(big.NewInt(5), rand.Reader)
-	cypher2, _ := privateKey.Encrypt(big.NewInt(6), rand.Reader)
-	cypher3, _ := privateKey.Encrypt(big.NewInt(7), rand.Reader)
-	cypher4, _ := privateKey.Encrypt(big.NewInt(8), rand.Reader)
-	cypher5 := privateKey.Add(cypher1, cypher2, cypher3, cypher4)
+	cypher1, _ := SecretKey.Encrypt(big.NewInt(5), rand.Reader)
+	cypher2, _ := SecretKey.Encrypt(big.NewInt(6), rand.Reader)
+	cypher3, _ := SecretKey.Encrypt(big.NewInt(7), rand.Reader)
+	cypher4, _ := SecretKey.Encrypt(big.NewInt(8), rand.Reader)
+	cypher5 := SecretKey.Add(cypher1, cypher2, cypher3, cypher4)
 
-	m := privateKey.Decrypt(cypher5)
+	m := SecretKey.Decrypt(cypher5)
 	if m.Cmp(big.NewInt(26)) != 0 {
 		t.Errorf("Unexpected decrypted value [%v]", m)
 	}
 }
 
 func TestAddCypherWithSmallKeyModulus(t *testing.T) {
-	privateKey := CreatePrivateKey(big.NewInt(7), big.NewInt(5))
+	SecretKey := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
-	cypher1, _ := privateKey.Encrypt(big.NewInt(30), rand.Reader)
-	cypher2, _ := privateKey.Encrypt(big.NewInt(25), rand.Reader)
-	cypher3, _ := privateKey.Encrypt(big.NewInt(11), rand.Reader)
-	cypher4 := privateKey.Add(cypher1, cypher2, cypher3)
+	cypher1, _ := SecretKey.Encrypt(big.NewInt(30), rand.Reader)
+	cypher2, _ := SecretKey.Encrypt(big.NewInt(25), rand.Reader)
+	cypher3, _ := SecretKey.Encrypt(big.NewInt(11), rand.Reader)
+	cypher4 := SecretKey.Add(cypher1, cypher2, cypher3)
 
-	m := privateKey.Decrypt(cypher4)
+	m := SecretKey.Decrypt(cypher4)
 	if m.Cmp(big.NewInt(31)) != 0 {
 		t.Errorf("Unexpected decrypted value [%v]", m)
 	}
 }
 
 func TestMulCypher(t *testing.T) {
-	privateKey := CreatePrivateKey(big.NewInt(17), big.NewInt(13))
+	SecretKey := CreateSecretKey(big.NewInt(17), big.NewInt(13))
 
-	cypher, err := privateKey.Encrypt(big.NewInt(3), rand.Reader)
+	cypher, err := SecretKey.Encrypt(big.NewInt(3), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cypherMultiple := privateKey.Mul(cypher, big.NewInt(7))
-	multiple := privateKey.Decrypt(cypherMultiple)
+	cypherMultiple := SecretKey.Mul(cypher, big.NewInt(7))
+	multiple := SecretKey.Decrypt(cypherMultiple)
 
 	// 3 * 7 = 21
 	if multiple.Cmp(big.NewInt(21)) != 0 {
@@ -171,15 +171,15 @@ func TestMulCypher(t *testing.T) {
 }
 
 func TestMulCypherWithSmallKeyModulus(t *testing.T) {
-	privateKey := CreatePrivateKey(big.NewInt(7), big.NewInt(5))
+	SecretKey := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
-	cypher, err := privateKey.Encrypt(big.NewInt(30), rand.Reader)
+	cypher, err := SecretKey.Encrypt(big.NewInt(30), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cypherMultiple := privateKey.Mul(cypher, big.NewInt(93))
-	multiple := privateKey.Decrypt(cypherMultiple)
+	cypherMultiple := SecretKey.Mul(cypher, big.NewInt(93))
+	multiple := SecretKey.Decrypt(cypherMultiple)
 
 	// (30*93) mod (7*5) = 25
 	if multiple.Cmp(big.NewInt(25)) != 0 {

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -124,7 +124,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 	}
 }
 
-func TestAddCyphers(t *testing.T) {
+func TestAddCiphertexts(t *testing.T) {
 	p, q := GenKeyPrimes(10)
 	sk := CreateSecretKey(p, q)
 
@@ -140,7 +140,7 @@ func TestAddCyphers(t *testing.T) {
 	}
 }
 
-func TestAddCypherWithSmallKeyModulus(t *testing.T) {
+func TestAddCiphertextWithSmallKeyModulus(t *testing.T) {
 	sk := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
 	ct1, _ := sk.Encrypt(big.NewInt(30), rand.Reader)
@@ -154,7 +154,7 @@ func TestAddCypherWithSmallKeyModulus(t *testing.T) {
 	}
 }
 
-func TestMulCypher(t *testing.T) {
+func TestMulCiphertext(t *testing.T) {
 	p, q := GenKeyPrimes(10)
 	sk := CreateSecretKey(p, q)
 
@@ -172,7 +172,7 @@ func TestMulCypher(t *testing.T) {
 	}
 }
 
-func TestMulCypherWithSmallKeyModulus(t *testing.T) {
+func TestMulCiphertextWithSmallKeyModulus(t *testing.T) {
 	sk := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
 	ct, err := sk.Encrypt(big.NewInt(30), rand.Reader)
@@ -197,7 +197,7 @@ func GenKeyPrimes(bits int) (p, q *big.Int) {
 			continue
 		}
 		q, err = rand.Prime(rand.Reader, bits)
-		if err != nil {
+		if err != nil || p.Cmp(q) == 0 {
 			continue
 		}
 

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -36,29 +36,29 @@ func TestCreateSecretKey(t *testing.T) {
 	p := big.NewInt(463)
 	q := big.NewInt(631)
 
-	SecretKey := CreateSecretKey(p, q)
+	sk := CreateSecretKey(p, q)
 
-	if SecretKey.N.Cmp(big.NewInt(292153)) != 0 {
-		t.Errorf("Unexpected N PublicKey value [%v]", SecretKey.N)
+	if sk.N.Cmp(big.NewInt(292153)) != 0 {
+		t.Errorf("Unexpected N PublicKey value [%v]", sk.N)
 	}
 
-	if SecretKey.Lambda.Cmp(big.NewInt(291060)) != 0 {
-		t.Errorf("Unexpected Lambda Public key value [%v]", SecretKey.Lambda)
+	if sk.Lambda.Cmp(big.NewInt(291060)) != 0 {
+		t.Errorf("Unexpected Lambda Public key value [%v]", sk.Lambda)
 	}
 }
 
 func TestEncryptDecryptSmall(t *testing.T) {
-	p := big.NewInt(13)
-	q := big.NewInt(11)
-	for i := 1; i < 10; i++ {
-		SecretKey := CreateSecretKey(p, q)
+	for i := 1; i < 100; i++ {
+
+		p, q := GenKeyPrimes(10)
+		sk := CreateSecretKey(p, q)
 
 		initialValue := big.NewInt(100)
-		ct, err := SecretKey.Encrypt(initialValue, rand.Reader)
+		ct, err := sk.Encrypt(initialValue, rand.Reader)
 		if err != nil {
 			t.Error(err)
 		}
-		returnedValue := SecretKey.Decrypt(ct)
+		returnedValue := sk.Decrypt(ct)
 		if initialValue.Cmp(returnedValue) != 0 {
 			t.Error("wrong decryption ", returnedValue, " is not ", initialValue)
 		}
@@ -70,7 +70,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 	q := big.NewInt(11)
 
 	// N = pq = 143 so the plaintext space is [0, 143)
-	SecretKey := CreateSecretKey(p, q)
+	sk := CreateSecretKey(p, q)
 
 	var tests = map[string]struct {
 		plaintext     *big.Int
@@ -101,7 +101,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			ct, err := SecretKey.Encrypt(test.plaintext, rand.Reader)
+			ct, err := sk.Encrypt(test.plaintext, rand.Reader)
 			if !reflect.DeepEqual(err, test.expectedError) {
 				t.Errorf(
 					"Unexpected error\nExpected: %v\nActual: %v",
@@ -111,7 +111,7 @@ func TestCheckPlaintextSpace(t *testing.T) {
 			}
 
 			if test.expectedError == nil {
-				decrypted := SecretKey.Decrypt(ct)
+				decrypted := sk.Decrypt(ct)
 				if test.plaintext.Cmp(decrypted) != 0 {
 					t.Errorf(
 						"Unexpected decryption\nExpected: %v\nActual: %v",
@@ -125,44 +125,46 @@ func TestCheckPlaintextSpace(t *testing.T) {
 }
 
 func TestAddCyphers(t *testing.T) {
-	SecretKey := CreateSecretKey(big.NewInt(17), big.NewInt(13))
+	p, q := GenKeyPrimes(10)
+	sk := CreateSecretKey(p, q)
 
-	cypher1, _ := SecretKey.Encrypt(big.NewInt(5), rand.Reader)
-	cypher2, _ := SecretKey.Encrypt(big.NewInt(6), rand.Reader)
-	cypher3, _ := SecretKey.Encrypt(big.NewInt(7), rand.Reader)
-	cypher4, _ := SecretKey.Encrypt(big.NewInt(8), rand.Reader)
-	cypher5 := SecretKey.Add(cypher1, cypher2, cypher3, cypher4)
+	ct1, _ := sk.Encrypt(big.NewInt(5), rand.Reader)
+	ct2, _ := sk.Encrypt(big.NewInt(6), rand.Reader)
+	ct3, _ := sk.Encrypt(big.NewInt(7), rand.Reader)
+	ct4, _ := sk.Encrypt(big.NewInt(8), rand.Reader)
+	ct5 := sk.Add(ct1, ct2, ct3, ct4)
 
-	m := SecretKey.Decrypt(cypher5)
+	m := sk.Decrypt(ct5)
 	if m.Cmp(big.NewInt(26)) != 0 {
 		t.Errorf("Unexpected decrypted value [%v]", m)
 	}
 }
 
 func TestAddCypherWithSmallKeyModulus(t *testing.T) {
-	SecretKey := CreateSecretKey(big.NewInt(7), big.NewInt(5))
+	sk := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
-	cypher1, _ := SecretKey.Encrypt(big.NewInt(30), rand.Reader)
-	cypher2, _ := SecretKey.Encrypt(big.NewInt(25), rand.Reader)
-	cypher3, _ := SecretKey.Encrypt(big.NewInt(11), rand.Reader)
-	cypher4 := SecretKey.Add(cypher1, cypher2, cypher3)
+	ct1, _ := sk.Encrypt(big.NewInt(30), rand.Reader)
+	ct2, _ := sk.Encrypt(big.NewInt(25), rand.Reader)
+	ct3, _ := sk.Encrypt(big.NewInt(11), rand.Reader)
+	ct4 := sk.Add(ct1, ct2, ct3)
 
-	m := SecretKey.Decrypt(cypher4)
+	m := sk.Decrypt(ct4)
 	if m.Cmp(big.NewInt(31)) != 0 {
 		t.Errorf("Unexpected decrypted value [%v]", m)
 	}
 }
 
 func TestMulCypher(t *testing.T) {
-	SecretKey := CreateSecretKey(big.NewInt(17), big.NewInt(13))
+	p, q := GenKeyPrimes(10)
+	sk := CreateSecretKey(p, q)
 
-	ct, err := SecretKey.Encrypt(big.NewInt(3), rand.Reader)
+	ct, err := sk.Encrypt(big.NewInt(3), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cypherMultiple := SecretKey.Mul(ct, big.NewInt(7))
-	multiple := SecretKey.Decrypt(cypherMultiple)
+	ctMultiple := sk.Mul(ct, big.NewInt(7))
+	multiple := sk.Decrypt(ctMultiple)
 
 	// 3 * 7 = 21
 	if multiple.Cmp(big.NewInt(21)) != 0 {
@@ -171,18 +173,36 @@ func TestMulCypher(t *testing.T) {
 }
 
 func TestMulCypherWithSmallKeyModulus(t *testing.T) {
-	SecretKey := CreateSecretKey(big.NewInt(7), big.NewInt(5))
+	sk := CreateSecretKey(big.NewInt(7), big.NewInt(5))
 
-	ct, err := SecretKey.Encrypt(big.NewInt(30), rand.Reader)
+	ct, err := sk.Encrypt(big.NewInt(30), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cypherMultiple := SecretKey.Mul(ct, big.NewInt(93))
-	multiple := SecretKey.Decrypt(cypherMultiple)
+	ctMultiple := sk.Mul(ct, big.NewInt(93))
+	multiple := sk.Decrypt(ctMultiple)
 
 	// (30*93) mod (7*5) = 25
 	if multiple.Cmp(big.NewInt(25)) != 0 {
 		t.Errorf("Unexpected decrypted value [%v]", multiple)
 	}
+}
+
+func GenKeyPrimes(bits int) (p, q *big.Int) {
+	var err error
+	for {
+		p, err = rand.Prime(rand.Reader, bits)
+		if err != nil {
+			continue
+		}
+		q, err = rand.Prime(rand.Reader, bits)
+		if err != nil {
+			continue
+		}
+
+		break
+	}
+
+	return p, q
 }

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -171,7 +171,7 @@ func (tk *ThresholdPublicKey) VerifyDecryption(encryptedMessage, decryptedMessag
 	return nil
 }
 
-// Private key for a threshold Paillier scheme. Holds private information
+// Private key for a threshold Paillier scheme. Holds skate information
 // for the given decryption server.
 // `Id` is the unique identifier of a decryption server and `Share` is a secret
 // share generated from hiding polynomial and is used for a partial share decryption.

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -181,7 +181,7 @@ type ThresholdSecretKey struct {
 	Share *big.Int
 }
 
-// Decrypts the cypher text and returns the partial decryption
+// Decrypts the ct text and returns the partial decryption
 func (tpk *ThresholdSecretKey) Decrypt(c *big.Int) *PartialDecryption {
 	ret := new(PartialDecryption)
 	ret.Id = tpk.Id
@@ -334,7 +334,7 @@ type PartialDecryptionZKP struct {
 	Key *ThresholdPublicKey // the public key used to encrypt
 	E   *big.Int            // the challenge
 	Z   *big.Int            // the value needed to check to verify the decryption
-	C   *big.Int            // the input cypher text
+	C   *big.Int            // the input ct text
 }
 
 func (pd *PartialDecryptionZKP) verifyPart1() *big.Int {

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -224,7 +224,7 @@ func (tpk *ThresholdSecretKey) computeHash(a, b, c4, ci2 *big.Int) *big.Int {
 	return new(big.Int).SetBytes(hash.Sum([]byte{}))
 }
 
-func (tpk *ThresholdSecretKey) DecryptAndProduceZNP(c *big.Int, random io.Reader) (*PartialDecryptionZKP, error) {
+func (tpk *ThresholdSecretKey) DecryptAndProduceZKP(c *big.Int, random io.Reader) (*PartialDecryptionZKP, error) {
 	pd := new(PartialDecryptionZKP)
 	pd.Key = tpk.getThresholdKey()
 	pd.C = c
@@ -264,7 +264,7 @@ func (tpk *ThresholdSecretKey) Validate(random io.Reader) error {
 	if err != nil {
 		return err
 	}
-	proof, err := tpk.DecryptAndProduceZNP(c.C, random)
+	proof, err := tpk.DecryptAndProduceZKP(c.C, random)
 	if err != nil {
 		return err
 	}

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -175,14 +175,14 @@ func (tk *ThresholdPublicKey) VerifyDecryption(encryptedMessage, decryptedMessag
 // for the given decryption server.
 // `Id` is the unique identifier of a decryption server and `Share` is a secret
 // share generated from hiding polynomial and is used for a partial share decryption.
-type ThresholdPrivateKey struct {
+type ThresholdSecretKey struct {
 	ThresholdPublicKey
 	Id    int
 	Share *big.Int
 }
 
 // Decrypts the cypher text and returns the partial decryption
-func (tpk *ThresholdPrivateKey) Decrypt(c *big.Int) *PartialDecryption {
+func (tpk *ThresholdSecretKey) Decrypt(c *big.Int) *PartialDecryption {
 	ret := new(PartialDecryption)
 	ret.Id = tpk.Id
 	exp := new(big.Int).Mul(tpk.Share, new(big.Int).Mul(TWO, tpk.delta()))
@@ -191,7 +191,7 @@ func (tpk *ThresholdPrivateKey) Decrypt(c *big.Int) *PartialDecryption {
 	return ret
 }
 
-func (tpk *ThresholdPrivateKey) copyVi() []*big.Int {
+func (tpk *ThresholdSecretKey) copyVi() []*big.Int {
 	ret := make([]*big.Int, len(tpk.Vi))
 	for i, vi := range tpk.Vi {
 		ret[i] = new(big.Int).Add(vi, big.NewInt(0))
@@ -199,7 +199,7 @@ func (tpk *ThresholdPrivateKey) copyVi() []*big.Int {
 	return ret
 }
 
-func (tpk *ThresholdPrivateKey) getThresholdKey() *ThresholdPublicKey {
+func (tpk *ThresholdSecretKey) getThresholdKey() *ThresholdPublicKey {
 	ret := new(ThresholdPublicKey)
 	ret.Threshold = tpk.Threshold
 	ret.TotalNumberOfDecryptionServers = tpk.TotalNumberOfDecryptionServers
@@ -209,13 +209,13 @@ func (tpk *ThresholdPrivateKey) getThresholdKey() *ThresholdPublicKey {
 	return ret
 }
 
-func (tpk *ThresholdPrivateKey) computeZ(r, e *big.Int) *big.Int {
+func (tpk *ThresholdSecretKey) computeZ(r, e *big.Int) *big.Int {
 	tmp := new(big.Int).Mul(e, tpk.delta())
 	tmp = new(big.Int).Mul(tmp, tpk.Share)
 	return new(big.Int).Add(r, tmp)
 }
 
-func (tpk *ThresholdPrivateKey) computeHash(a, b, c4, ci2 *big.Int) *big.Int {
+func (tpk *ThresholdSecretKey) computeHash(a, b, c4, ci2 *big.Int) *big.Int {
 	hash := sha256.New()
 	hash.Write(a.Bytes())
 	hash.Write(b.Bytes())
@@ -224,7 +224,7 @@ func (tpk *ThresholdPrivateKey) computeHash(a, b, c4, ci2 *big.Int) *big.Int {
 	return new(big.Int).SetBytes(hash.Sum([]byte{}))
 }
 
-func (tpk *ThresholdPrivateKey) DecryptAndProduceZNP(c *big.Int, random io.Reader) (*PartialDecryptionZKP, error) {
+func (tpk *ThresholdSecretKey) DecryptAndProduceZNP(c *big.Int, random io.Reader) (*PartialDecryptionZKP, error) {
 	pd := new(PartialDecryptionZKP)
 	pd.Key = tpk.getThresholdKey()
 	pd.C = c
@@ -255,7 +255,7 @@ func (tpk *ThresholdPrivateKey) DecryptAndProduceZNP(c *big.Int, random io.Reade
 
 // Verifies if the partial decryption key is well formed.  If well formed,
 // the method return nil else an explicative error is returned.
-func (tpk *ThresholdPrivateKey) Validate(random io.Reader) error {
+func (tpk *ThresholdSecretKey) Validate(random io.Reader) error {
 	m, err := rand.Int(random, tpk.N)
 	if err != nil {
 		return err
@@ -281,7 +281,7 @@ type PartialDecryption struct {
 
 // A non-interactive ZKP based on the Fiat–Shamir heuristic. This algorithm
 // proves that the decryption server indeed raised secret to his secret exponent
-// (`ThresholdPrivateKey.Share`) by comparison with the public verification key
+// (`ThresholdSecretKey.Share`) by comparison with the public verification key
 // (`ThresholdKey.Vi`). Recall that v_i = v^(delta s_i).
 //
 // The Fiat-Shamir is a non-interactive proof of knowledge heuristic.

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -171,7 +171,7 @@ func (tk *ThresholdPublicKey) VerifyDecryption(encryptedMessage, decryptedMessag
 	return nil
 }
 
-// Private key for a threshold Paillier scheme. Holds skate information
+// Secret key for a threshold Paillier scheme. Holds skate information
 // for the given decryption server.
 // `Id` is the unique identifier of a decryption server and `Share` is a secret
 // share generated from hiding polynomial and is used for a partial share decryption.
@@ -297,7 +297,7 @@ type PartialDecryption struct {
 //
 // In our case:
 //
-// Decryption server i wants to prove that he indeed raised the cyphertext to
+// Decryption server i wants to prove that he indeed raised the ciphertext to
 // his secret exponent s_i during partial decryption.
 // This is essentialy a protocol for the equality of discrete logs,
 // log_{c^4}(c_i^2) = log_v(v_i).
@@ -309,7 +309,7 @@ type PartialDecryption struct {
 //   E = HASH(a, b, c^4, c_i^2), where
 //     a = (c^4)^r mod n^2
 //     b = V^r mod n^2
-//     c is a cyphertext,
+//     c is a ciphertext,
 //     V is a generator from ThresholdKey.V
 //     c_i is a partial decryption for this server
 // - Compute Z as:

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -240,8 +240,8 @@ func (tkg *ThresholdKeyGenerator) createViArray(shares []*big.Int) (viArray []*b
 	return viArray
 }
 
-func (tkg *ThresholdKeyGenerator) createPrivateKey(i int, share *big.Int, viArray []*big.Int) *ThresholdPrivateKey {
-	ret := new(ThresholdPrivateKey)
+func (tkg *ThresholdKeyGenerator) createSecretKey(i int, share *big.Int, viArray []*big.Int) *ThresholdSecretKey {
+	ret := new(ThresholdSecretKey)
 	ret.N = tkg.n
 	ret.V = tkg.v
 
@@ -253,22 +253,22 @@ func (tkg *ThresholdKeyGenerator) createPrivateKey(i int, share *big.Int, viArra
 	return ret
 }
 
-func (tkg *ThresholdKeyGenerator) createPrivateKeys() []*ThresholdPrivateKey {
+func (tkg *ThresholdKeyGenerator) createSecretKeys() []*ThresholdSecretKey {
 	shares := tkg.createShares()
 	viArray := tkg.createViArray(shares)
-	ret := make([]*ThresholdPrivateKey, tkg.TotalNumberOfDecryptionServers)
+	ret := make([]*ThresholdSecretKey, tkg.TotalNumberOfDecryptionServers)
 	for i := 0; i < tkg.TotalNumberOfDecryptionServers; i++ {
-		ret[i] = tkg.createPrivateKey(i, shares[i], viArray)
+		ret[i] = tkg.createSecretKey(i, shares[i], viArray)
 	}
 	return ret
 }
 
-func (tkg *ThresholdKeyGenerator) Generate() ([]*ThresholdPrivateKey, error) {
+func (tkg *ThresholdKeyGenerator) Generate() ([]*ThresholdSecretKey, error) {
 	if err := tkg.initNumerialValues(); err != nil {
 		return nil, err
 	}
 	if err := tkg.generateHidingPolynomial(); err != nil {
 		return nil, err
 	}
-	return tkg.createPrivateKeys(), nil
+	return tkg.createSecretKeys(), nil
 }

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -243,6 +243,7 @@ func (tkg *ThresholdKeyGenerator) createViArray(shares []*big.Int) (viArray []*b
 func (tkg *ThresholdKeyGenerator) createSecretKey(i int, share *big.Int, viArray []*big.Int) *ThresholdSecretKey {
 	ret := new(ThresholdSecretKey)
 	ret.N = tkg.n
+	ret.G = new(big.Int).Add(tkg.n, big.NewInt(1))
 	ret.V = tkg.v
 
 	ret.TotalNumberOfDecryptionServers = tkg.TotalNumberOfDecryptionServers

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func getThresholdPrivateKey() *ThresholdPrivateKey {
+func getThresholdSecretKey() *ThresholdSecretKey {
 	tkh, err := GetThresholdKeyGenerator(32, 10, 6, rand.Reader)
 	if err != nil {
 		panic(err)
@@ -55,7 +55,7 @@ func TestCombineSharesConstant(t *testing.T) {
 }
 
 func TestDecrypt(t *testing.T) {
-	key := new(ThresholdPrivateKey)
+	key := new(ThresholdSecretKey)
 	key.TotalNumberOfDecryptionServers = 10
 	key.N = b(101 * 103)
 	key.Share = b(862)
@@ -73,7 +73,7 @@ func TestDecrypt(t *testing.T) {
 }
 
 func TestCopyVi(t *testing.T) {
-	key := new(ThresholdPrivateKey)
+	key := new(ThresholdSecretKey)
 	key.Vi = []*big.Int{b(34), b(2), b(29)}
 	vi := key.copyVi()
 	if !reflect.DeepEqual(vi, key.Vi) {
@@ -86,7 +86,7 @@ func TestCopyVi(t *testing.T) {
 }
 
 func TestEncryptWithThresholdKey(t *testing.T) {
-	pd := getThresholdPrivateKey()
+	pd := getThresholdSecretKey()
 	_, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Fail()
@@ -94,7 +94,7 @@ func TestEncryptWithThresholdKey(t *testing.T) {
 }
 
 func TestDecryptWithThresholdKey(t *testing.T) {
-	pd := getThresholdPrivateKey()
+	pd := getThresholdSecretKey()
 	c, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Fail()
@@ -131,7 +131,7 @@ func TestVerifyPart2(t *testing.T) {
 }
 
 func TestDecryptAndProduceZNP(t *testing.T) {
-	pd := getThresholdPrivateKey()
+	pd := getThresholdSecretKey()
 	c, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Error(err)
@@ -283,7 +283,7 @@ func TestDecryption(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	pk := getThresholdPrivateKey()
+	pk := getThresholdSecretKey()
 	if err := pk.Validate(rand.Reader); err != nil {
 		t.Error(err)
 	}

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -130,18 +130,18 @@ func TestVerifyPart2(t *testing.T) {
 	}
 }
 
-func TestDecryptAndProduceZNP(t *testing.T) {
+func TestDecryptAndProduceZKP(t *testing.T) {
 	pd := getThresholdSecretKey()
 	c, err := pd.Encrypt(big.NewInt(876), rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
-	znp, err := pd.DecryptAndProduceZNP(c.C, rand.Reader)
+	ZKP, err := pd.DecryptAndProduceZKP(c.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !znp.Verify() {
+	if !ZKP.Verify() {
 		t.Fail()
 	}
 }
@@ -308,11 +308,11 @@ func TestCombinePartialDecryptionsZKP(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	share1, err := tpks[0].DecryptAndProduceZNP(c.C, rand.Reader)
+	share1, err := tpks[0].DecryptAndProduceZKP(c.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
-	share2, err := tpks[1].DecryptAndProduceZNP(c.C, rand.Reader)
+	share2, err := tpks[1].DecryptAndProduceZKP(c.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
@@ -378,11 +378,11 @@ func TestVerifyDecryption(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	pd1, err := tpks[0].DecryptAndProduceZNP(ct.C, rand.Reader)
+	pd1, err := tpks[0].DecryptAndProduceZKP(ct.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
-	pd2, err := tpks[1].DecryptAndProduceZNP(ct.C, rand.Reader)
+	pd2, err := tpks[1].DecryptAndProduceZKP(ct.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -374,15 +374,15 @@ func TestVerifyDecryption(t *testing.T) {
 		t.Error(err)
 	}
 	expt := b(101)
-	cypher, err := tpks[0].Encrypt(expt, rand.Reader)
+	ct, err := tpks[0].Encrypt(expt, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
-	pd1, err := tpks[0].DecryptAndProduceZNP(cypher.C, rand.Reader)
+	pd1, err := tpks[0].DecryptAndProduceZNP(ct.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
-	pd2, err := tpks[1].DecryptAndProduceZNP(cypher.C, rand.Reader)
+	pd2, err := tpks[1].DecryptAndProduceZNP(ct.C, rand.Reader)
 	if err != nil {
 		t.Error(err)
 	}
@@ -391,13 +391,13 @@ func TestVerifyDecryption(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err = pk.VerifyDecryption(cypher.C, b(101), pds); err != nil {
+	if err = pk.VerifyDecryption(ct.C, b(101), pds); err != nil {
 		t.Error(err)
 	}
-	if err = pk.VerifyDecryption(cypher.C, b(100), pds); err == nil {
+	if err = pk.VerifyDecryption(ct.C, b(100), pds); err == nil {
 		t.Error(err)
 	}
-	if err = pk.VerifyDecryption(new(big.Int).Add(b(1), cypher.C), b(101), pds); err == nil {
+	if err = pk.VerifyDecryption(new(big.Int).Add(b(1), ct.C), b(101), pds); err == nil {
 		t.Error(err)
 	}
 }

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -234,7 +234,7 @@ func TestEncryptingDecrypting(t *testing.T) {
 		t.Error(err)
 	}
 	if n(message) != n(message2) {
-		t.Error("The decrypted cyphered is not original massage but ", message2)
+		t.Error("The decrypted ciphered is not original massage but ", message2)
 	}
 }
 
@@ -249,13 +249,13 @@ func TestHomomorphicThresholdEncryption(t *testing.T) {
 	plainText1 := b(13)
 	plainText2 := b(19)
 
-	cypher1, _ := tpks[0].Encrypt(plainText1, rand.Reader)
-	cypher2, _ := tpks[1].Encrypt(plainText2, rand.Reader)
+	cipher1, _ := tpks[0].Encrypt(plainText1, rand.Reader)
+	cipher2, _ := tpks[1].Encrypt(plainText2, rand.Reader)
 
-	cypher3 := tpks[0].Add(cypher1, cypher2)
+	cipher3 := tpks[0].Add(cipher1, cipher2)
 
-	share1 := tpks[0].Decrypt(cypher3.C)
-	share2 := tpks[1].Decrypt(cypher3.C)
+	share1 := tpks[0].Decrypt(cipher3.C)
+	share2 := tpks[1].Decrypt(cipher3.C)
 
 	combined, _ := tpks[0].CombinePartialDecryptions([]*PartialDecryption{share1, share2})
 
@@ -321,7 +321,7 @@ func TestCombinePartialDecryptionsZKP(t *testing.T) {
 		t.Error(err)
 	}
 	if n(message) != n(message2) {
-		t.Error("The decrypted cyphered is not original massage but ", message2)
+		t.Error("The decrypted ciphered is not original massage but ", message2)
 	}
 	share1.E = b(687687678)
 	_, err = tpks[0].CombinePartialDecryptionsZKP([]*PartialDecryptionZKP{share1, share2})
@@ -357,7 +357,7 @@ func TestCombinePartialDecryptionsWith100Shares(t *testing.T) {
 		t.Error(err)
 	}
 	if n(message) != n(message2) {
-		t.Error("The decrypted cyphered is not original massage but ", message2)
+		t.Error("The decrypted ciphered is not original massage but ", message2)
 	}
 }
 


### PR DESCRIPTION
Fixed some spelling issues and generally made the code follow cryptosystem naming conventions:
 1) changed Cypher -> Ciphertext 
 2) PrivateKey -> SecretKey
 3) ZNP -> ZKP (since it's zero-knowledge proofs...)

Also made the test for Dec(Enc(m)) = m more robust by generating keys on each run (instead of having a fixed keypair) as I ran into an issue where the previous tests passed. 